### PR TITLE
fix(p1): correctness pass

### DIFF
--- a/backend/src/controllers/blog.ts
+++ b/backend/src/controllers/blog.ts
@@ -494,27 +494,24 @@ export const getPublishedSingleBlogHandler = async (
   }
 };
 
+// Public, anonymous "like" — no auth. Increments by 1 atomically (the client
+// value is not trusted) and only for a published post owned by `:username`.
 export const updateLikesCountHandler = async (
   req: Request,
   res: Response,
   next: NextFunction
 ) => {
-  // @ts-ignore
-  const userId = req?.userId;
   const blogId = parseInt(req.params.id);
   const username = req.params.username;
-  const { likes_count } = req.body;
 
   try {
-    // find the blog
-    const blog = await prisma.blog.findUnique({
+    const blog = await prisma.blog.findFirst({
       where: {
-        id: +blogId,
-        userId: userId,
-        user: {
-          username,
-        },
+        id: blogId,
+        is_draft: false,
+        user: { username },
       },
+      select: { id: true },
     });
 
     if (!blog) {
@@ -523,28 +520,15 @@ export const updateLikesCountHandler = async (
       throw error;
     }
 
-    const updatedContent = {
-      ...blog,
-      likes_count: +blog?.likes_count + likes_count,
-    };
-
     const updatedBlog = await prisma.blog.update({
-      where: {
-        id: +blogId,
-        userId: userId,
-      },
-      data: updatedContent,
+      where: { id: blog.id },
+      data: { likes_count: { increment: 1 } },
+      select: { likes_count: true },
     });
 
-    if (!updatedBlog) {
-      const error = new CustomError("Could not update blog");
-      error.statusCode = HTTP_STATUS_CODES.StatusInternalServerError;
-      throw error;
-    }
-
     res.status(HTTP_STATUS_CODES.StatusOk).json({
-      message: "Blog was updated successfully",
-      data: [],
+      message: "Blog was liked successfully",
+      data: { likes_count: updatedBlog.likes_count },
     });
   } catch (error) {
     next(error);

--- a/frontend/src/components/forms/ProjectForm.tsx
+++ b/frontend/src/components/forms/ProjectForm.tsx
@@ -202,7 +202,7 @@ const ProjectForm: React.FC<IProjectFormComponentProps> = ({
         <Button
           size="sm"
           type="submit"
-          form="add-blog"
+          form="add-project"
           variant="outlined"
           colorType="success"
         >
@@ -224,7 +224,7 @@ const ProjectForm: React.FC<IProjectFormComponentProps> = ({
 
       <section className="" id="add-project-section">
         <form
-          id="add-blog"
+          id="add-project"
           className="space-y-4"
           onSubmit={handleSubmit(handleProjectSubmit)}
         >

--- a/frontend/src/components/sections/BlogsSection.tsx
+++ b/frontend/src/components/sections/BlogsSection.tsx
@@ -6,9 +6,11 @@ const BlogsSection = () => {
   const { blogs, isGettingBlogs } = useGetBlogs();
 
   if (isGettingBlogs) {
-    <section className="flex items-center justify-center p-2 my-10">
-      <ClipLoader size={6} />
-    </section>;
+    return (
+      <section className="flex items-center justify-center p-2 my-10">
+        <ClipLoader size={6} />
+      </section>
+    );
   }
 
   if (!blogs || blogs?.length === 0) {

--- a/frontend/src/components/sections/ProjectSection.tsx
+++ b/frontend/src/components/sections/ProjectSection.tsx
@@ -6,9 +6,11 @@ const ProjectSection = () => {
   const { isGettingProjects, projects } = useGetProjects();
 
   if (isGettingProjects) {
-    <section className="flex items-center justify-center p-2 my-10">
-      <ClipLoader size={6} />
-    </section>;
+    return (
+      <section className="flex items-center justify-center p-2 my-10">
+        <ClipLoader size={6} />
+      </section>
+    );
   }
 
   if (!projects || projects?.length === 0) {

--- a/frontend/src/services/blog/update-blog.ts
+++ b/frontend/src/services/blog/update-blog.ts
@@ -11,7 +11,7 @@ const updateBlog = async (id: string, data: IBlogFormProps) => {
 
 export const useUpdateBlog = () => {
   const mutation = useMutation({
-    mutationKey: ["create-blog"],
+    mutationKey: ["update-blog"],
     mutationFn: ({ data, id }: { data: IBlogFormProps; id: string }) =>
       updateBlog(id, data),
   });

--- a/frontend/src/services/projects/update-project.ts
+++ b/frontend/src/services/projects/update-project.ts
@@ -11,7 +11,7 @@ const updateProject = async (id: string, data: IProjectFormProps) => {
 
 export const useUpdateProject = () => {
   const mutation = useMutation({
-    mutationKey: ["create-project"],
+    mutationKey: ["update-project"],
     mutationFn: ({ data, id }: { data: IProjectFormProps; id: string }) =>
       updateProject(id, data),
   });


### PR DESCRIPTION
- Blogs/Projects list sections: add the missing `return` so the loading spinner actually renders (was a no-op JSX expression).
- ProjectForm: rename the form id + submit button target from "add-blog" to "add-project" (was mislabeled).
- Update mutations: use distinct mutation keys ("update-blog"/"update-project") instead of the create keys.
- Public like endpoint: make updateLikesCountHandler truly anonymous — the route has no auth, so it no longer relies on req.userId; it now finds the published post by username + id and increments likes_count atomically by 1 (client-sent count is no longer trusted; drafts can't be liked).

Note: the publish toggle reads oddly ("shouldPublish") but is correct end-to-end (caller passes !is_draft, handler sets is_draft to it) — left as is.