### PR TITLE
feat(p2): signup page + refresh tokens

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -20,6 +20,16 @@ const __dirname = path.dirname(__filename);
 
 dotenv.config();
 
+// Fail fast on missing critical configuration rather than booting a broken server.
+const REQUIRED_ENV = ["JWT_SECRET_KEY", "DATABASE_URL"] as const;
+const missingEnv = REQUIRED_ENV.filter((key) => !process.env[key]);
+if (missingEnv.length > 0) {
+  console.error(
+    `Missing required environment variables: ${missingEnv.join(", ")}`
+  );
+  process.exit(1);
+}
+
 const app = express();
 
 // const globalLimiter = rateLimit({

--- a/backend/prisma/migrations/20251015000000_add_refresh_tokens/migration.sql
+++ b/backend/prisma/migrations/20251015000000_add_refresh_tokens/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "RefreshToken" (
+    "id" SERIAL NOT NULL,
+    "token_hash" TEXT NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" INTEGER NOT NULL,
+
+    CONSTRAINT "RefreshToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RefreshToken_token_hash_key" ON "RefreshToken"("token_hash");
+
+-- CreateIndex
+CREATE INDEX "RefreshToken_userId_idx" ON "RefreshToken"("userId");
+
+-- AddForeignKey
+ALTER TABLE "RefreshToken" ADD CONSTRAINT "RefreshToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -24,7 +24,21 @@ model User {
 
   blogs Blog[]
   projects Project[]
-  mediaFiles MediaFile[]  
+  mediaFiles MediaFile[]
+  refreshTokens RefreshToken[]
+}
+
+// Opaque, rotating refresh tokens (only a SHA-256 hash is stored).
+model RefreshToken {
+  id         Int      @id @default(autoincrement())
+  token_hash String   @unique
+  expires_at DateTime
+  created_at DateTime @default(now())
+
+  userId Int
+  user   User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
 }
 
 model Blog {

--- a/backend/src/configs/constants.ts
+++ b/backend/src/configs/constants.ts
@@ -1,1 +1,7 @@
-export const TOKEN_EXPIRY_TIME = 120 * 60;
+// Access token: short-lived (refreshed silently). Refresh token: long-lived,
+// rotated on every use.
+export const ACCESS_TOKEN_EXPIRY_TIME = 60 * 60; // seconds (1h)
+export const REFRESH_TOKEN_EXPIRY_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+// Back-compat alias for the old name.
+export const TOKEN_EXPIRY_TIME = ACCESS_TOKEN_EXPIRY_TIME;

--- a/backend/src/controllers/auth.ts
+++ b/backend/src/controllers/auth.ts
@@ -1,11 +1,28 @@
 import { NextFunction, Request, Response } from "express";
-import jwt from "jsonwebtoken";
 import bcrypt from "bcrypt";
+import slugify from "slugify";
 
 import HTTP_STATUS_CODES from "../utils/statusCodes.js";
 import CustomError from "../utils/customError.js";
-import { TOKEN_EXPIRY_TIME } from "../configs/constants.js";
 import prisma from "../prisma.js";
+import {
+  consumeRefreshToken,
+  createAccessToken,
+  issueRefreshToken,
+  revokeRefreshToken,
+} from "../utils/tokens.js";
+
+/** Builds a URL-safe, unique username from the user's name. */
+async function generateUniqueUsername(first: string, last: string) {
+  const base =
+    slugify.default(`${first} ${last}`, { lower: true, strict: true }) || "user";
+  let username = base;
+  let suffix = 1;
+  while (await prisma.user.findUnique({ where: { username } })) {
+    username = `${base}-${suffix++}`;
+  }
+  return username;
+}
 
 export const createUserHandler = async (
   req: Request,
@@ -29,7 +46,7 @@ export const createUserHandler = async (
     let hashedPassword;
 
     const result = await bcrypt.hash(password, 12);
-    const username = `${first_name?.toLowerCase()}_${last_name?.toLowerCase()}_`;
+    const username = await generateUniqueUsername(first_name, last_name);
 
     if (result) {
       hashedPassword = result;
@@ -95,31 +112,77 @@ export const loginHandler = async (
     const isMatch = await bcrypt.compare(plainPassword, user?.password);
 
     if (isMatch) {
-      // create token for the user
-      const token = jwt.sign(
-        {
-          userId: user?.id,
-          email: user?.email,
-        },
-        process.env.JWT_SECRET_KEY!,
-        {
-          expiresIn: TOKEN_EXPIRY_TIME,
-          algorithm: "HS256",
-        }
-      );
+      const access = createAccessToken({ id: user.id, email: user.email });
+      const refresh = await issueRefreshToken(user.id);
 
       res.status(200).json({
         message: "login was successful",
-        token,
-        expiresAt: new Date(
-          Date.now() + TOKEN_EXPIRY_TIME * 1000
-        ).toISOString(),
+        token: access.token,
+        expiresAt: access.expiresAt.toISOString(),
+        refreshToken: refresh.token,
+        refreshExpiresAt: refresh.expiresAt.toISOString(),
       });
     } else {
       const error = new CustomError("Email or password is wrong!");
       error.statusCode = HTTP_STATUS_CODES.StatusUnprocessableEntity;
       throw error;
     }
+  } catch (error) {
+    next(error);
+  }
+};
+
+// Exchange a valid refresh token for a fresh access token + rotated refresh
+// token. The presented refresh token is consumed (single-use).
+export const refreshTokenHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const { refreshToken } = req.body;
+
+  try {
+    const userId = await consumeRefreshToken(refreshToken);
+
+    if (!userId) {
+      const error = new CustomError("Invalid or expired refresh token.");
+      error.statusCode = HTTP_STATUS_CODES.StatusUnauthorized;
+      throw error;
+    }
+
+    const user = await prisma.user.findUnique({ where: { id: userId } });
+    if (!user) {
+      const error = new CustomError("Invalid or expired refresh token.");
+      error.statusCode = HTTP_STATUS_CODES.StatusUnauthorized;
+      throw error;
+    }
+
+    const access = createAccessToken({ id: user.id, email: user.email });
+    const refresh = await issueRefreshToken(user.id);
+
+    res.status(HTTP_STATUS_CODES.StatusOk).json({
+      message: "token refreshed",
+      token: access.token,
+      expiresAt: access.expiresAt.toISOString(),
+      refreshToken: refresh.token,
+      refreshExpiresAt: refresh.expiresAt.toISOString(),
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+// Revoke a refresh token (logout). Always succeeds so the client can clear state.
+export const logoutHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const { refreshToken } = req.body;
+
+  try {
+    if (refreshToken) await revokeRefreshToken(refreshToken);
+    res.status(HTTP_STATUS_CODES.StatusOk).json({ message: "logged out" });
   } catch (error) {
     next(error);
   }

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -2,7 +2,12 @@ import express from "express";
 import { body } from "express-validator";
 import rateLimit from "express-rate-limit";
 
-import { createUserHandler, loginHandler } from "../controllers/auth.js";
+import {
+  createUserHandler,
+  loginHandler,
+  logoutHandler,
+  refreshTokenHandler,
+} from "../controllers/auth.js";
 import { errorValidator } from "../middlewares/validator.js";
 
 const router = express.Router();
@@ -77,6 +82,21 @@ router.post(
   ],
   errorValidator,
   loginHandler
+);
+
+router.post(
+  "/refresh",
+  authLimiter,
+  [body("refreshToken").trim().notEmpty().withMessage("Refresh token is required")],
+  errorValidator,
+  refreshTokenHandler
+);
+
+router.post(
+  "/logout",
+  [body("refreshToken").trim().notEmpty().withMessage("Refresh token is required")],
+  errorValidator,
+  logoutHandler
 );
 
 export { router };

--- a/backend/src/utils/tokens.ts
+++ b/backend/src/utils/tokens.ts
@@ -1,0 +1,57 @@
+import crypto from "node:crypto";
+import jwt from "jsonwebtoken";
+
+import {
+  ACCESS_TOKEN_EXPIRY_TIME,
+  REFRESH_TOKEN_EXPIRY_MS,
+} from "../configs/constants.js";
+import prisma from "../prisma.js";
+
+/** Signs a short-lived access JWT and returns it with its expiry. */
+export function createAccessToken(user: { id: number; email: string }) {
+  const token = jwt.sign(
+    { userId: user.id, email: user.email },
+    process.env.JWT_SECRET_KEY!,
+    { expiresIn: ACCESS_TOKEN_EXPIRY_TIME, algorithm: "HS256" }
+  );
+  const expiresAt = new Date(Date.now() + ACCESS_TOKEN_EXPIRY_TIME * 1000);
+  return { token, expiresAt };
+}
+
+const hashToken = (token: string) =>
+  crypto.createHash("sha256").update(token).digest("hex");
+
+/**
+ * Creates and persists a new refresh token (only its hash is stored) and
+ * returns the plaintext token + expiry to hand back to the client.
+ */
+export async function issueRefreshToken(userId: number) {
+  const token = crypto.randomBytes(48).toString("hex");
+  const expiresAt = new Date(Date.now() + REFRESH_TOKEN_EXPIRY_MS);
+  await prisma.refreshToken.create({
+    data: { token_hash: hashToken(token), userId, expires_at: expiresAt },
+  });
+  return { token, expiresAt };
+}
+
+/**
+ * Validates a refresh token and consumes it (single-use rotation): the
+ * presented token is always deleted. Returns the owning userId, or null if the
+ * token is unknown/expired.
+ */
+export async function consumeRefreshToken(token: string): Promise<number | null> {
+  const record = await prisma.refreshToken.findUnique({
+    where: { token_hash: hashToken(token) },
+  });
+  if (!record) return null;
+
+  await prisma.refreshToken.delete({ where: { id: record.id } }).catch(() => {});
+
+  if (record.expires_at.getTime() < Date.now()) return null;
+  return record.userId;
+}
+
+/** Revokes a refresh token (logout). No-op if it doesn't exist. */
+export async function revokeRefreshToken(token: string) {
+  await prisma.refreshToken.deleteMany({ where: { token_hash: hashToken(token) } });
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import ProtectedRoute from "./pages/ProtectedRoute";
 import { ClipLoader } from "react-spinners";
 
 const LoginPage = lazy(() => import("./pages/Login"));
+const SignupPage = lazy(() => import("./pages/Signup"));
 const HomePage = lazy(() => import("./pages/Home"));
 const BlogPage = lazy(() => import("./pages/Blogs"));
 const AddBlogPagePage = lazy(() => import("./pages/AddBlog"));
@@ -27,6 +28,7 @@ function App() {
       <QueryProvider>
         <Routes>
           <Route path="/login" element={<LoginPage />} />
+          <Route path="/sign-up" element={<SignupPage />} />
 
           <Route
             element={

--- a/frontend/src/components/common/HeaderNavigation.tsx
+++ b/frontend/src/components/common/HeaderNavigation.tsx
@@ -2,7 +2,7 @@
 import { NavLink, useNavigate } from "react-router";
 import { Button } from "./Button";
 import { useGetProfile } from "@/services/user-profile";
-import Cookies from "js-cookie";
+import { logout } from "@/core/http-service";
 import { useState } from "react";
 import BurgerBtn from "./BurgerBtn";
 import MobileSidebar from "./MobileSidebar";
@@ -16,8 +16,8 @@ const HeaderNavigation = () => {
 
   const { userInfo } = useGetProfile();
 
-  const handleLogOutUser = () => {
-    Cookies.remove("auth_token");
+  const handleLogOutUser = async () => {
+    await logout();
     navigate("/login");
   };
 

--- a/frontend/src/components/forms/AuthSignupForm.tsx
+++ b/frontend/src/components/forms/AuthSignupForm.tsx
@@ -1,0 +1,103 @@
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useState } from "react";
+
+import {
+  signupFormSchema,
+  type TSignupForm,
+} from "@/types/forms/auth.validations";
+import TextFieldController from "../common/text-field/TextFieldController";
+import { Button } from "../common/Button";
+import PasswordHidden from "../common/text-field/PasswordHidden";
+import { useSignupHandler } from "@/services/authentication/useSignup";
+
+const AuthSignupForm = () => {
+  const { handleSubmit, control } = useForm<TSignupForm>({
+    resolver: zodResolver(signupFormSchema),
+    defaultValues: {
+      first_name: "",
+      last_name: "",
+      email: "",
+      password: "",
+    },
+  });
+  const [isPassHidden, setIsPassHidden] = useState<boolean>(true);
+
+  const { isSigningUp, signupHandler } = useSignupHandler();
+
+  const signupSubmitHandler = (values: TSignupForm) => {
+    signupHandler(values);
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit(signupSubmitHandler)}
+      id="signup-form"
+      className="flex flex-col gap-y-4"
+    >
+      <div className="flex flex-col gap-y-4 sm:flex-row sm:gap-x-4">
+        <div className="flex w-full flex-col gap-y-2">
+          <TextFieldController
+            control={control}
+            name="first_name"
+            placeholder="First name"
+            dir="ltr"
+            variant="outlined"
+          />
+        </div>
+        <div className="flex w-full flex-col gap-y-2">
+          <TextFieldController
+            control={control}
+            name="last_name"
+            placeholder="Last name"
+            dir="ltr"
+            variant="outlined"
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-y-2">
+        <TextFieldController
+          control={control}
+          name="email"
+          type="email"
+          placeholder="Email"
+          dir="ltr"
+          variant="outlined"
+        />
+      </div>
+
+      <div className="flex flex-col gap-y-2">
+        <TextFieldController
+          control={control}
+          name="password"
+          type={isPassHidden ? "password" : "text"}
+          placeholder="password"
+          dir="ltr"
+          variant="outlined"
+          endAdornment={
+            <PasswordHidden
+              isHidden={isPassHidden}
+              onToggle={() => setIsPassHidden(!isPassHidden)}
+            />
+          }
+        />
+      </div>
+
+      <div className="w-full mt-6">
+        <Button
+          colorType="success"
+          className="w-full"
+          type="submit"
+          form="signup-form"
+          disabled={isSigningUp}
+          isLoading={isSigningUp}
+        >
+          Create account
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default AuthSignupForm;

--- a/frontend/src/core/http-service.ts
+++ b/frontend/src/core/http-service.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import type { InternalAxiosRequestConfig } from "axios";
 import Cookies from "js-cookie";
 
 import { errorHandler } from "./error-handler";
@@ -6,43 +7,100 @@ import ValidationError from "./validation-errors";
 
 export const API_URL = import.meta.env.VITE_API_BASE_URL || "";
 
+const ACCESS_COOKIE = "auth_token";
+const REFRESH_COOKIE = "refresh_token";
+
+export interface AuthTokens {
+  token: string;
+  expiresAt: string;
+  refreshToken: string;
+  refreshExpiresAt: string;
+}
+
+/** Persist the access + refresh tokens (cookie expiry matches each token's). */
+export function setAuthTokens(tokens: AuthTokens) {
+  Cookies.set(ACCESS_COOKIE, tokens.token, { expires: new Date(tokens.expiresAt) });
+  Cookies.set(REFRESH_COOKIE, tokens.refreshToken, {
+    expires: new Date(tokens.refreshExpiresAt),
+  });
+}
+
+export function clearAuthTokens() {
+  Cookies.remove(ACCESS_COOKIE);
+  Cookies.remove(REFRESH_COOKIE);
+}
+
 export const httpService = axios.create({
   baseURL: API_URL,
 });
 
 httpService.interceptors.request.use(
   (config) => {
-    const token = Cookies.get("auth_token");
+    const token = Cookies.get(ACCESS_COOKIE);
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }
     return config;
   },
-  (error) => {
-    return Promise.reject(error);
-  }
+  (error) => Promise.reject(error)
 );
 
+// Single-flight refresh: concurrent 401s share one /refresh call.
+let refreshPromise: Promise<string | null> | null = null;
+
+async function refreshAccessToken(): Promise<string | null> {
+  const refreshToken = Cookies.get(REFRESH_COOKIE);
+  if (!refreshToken) return null;
+
+  if (!refreshPromise) {
+    // Bare axios (not httpService) so this call skips the interceptors.
+    refreshPromise = axios
+      .post<AuthTokens>(`${API_URL}/refresh`, { refreshToken })
+      .then((res) => {
+        setAuthTokens(res.data);
+        return res.data.token;
+      })
+      .catch(() => null)
+      .finally(() => {
+        refreshPromise = null;
+      });
+  }
+  return refreshPromise;
+}
+
 httpService.interceptors.response.use(
-  (res) => {
-    return res;
-  },
-  (error) => {
-    const token = Cookies.get("auth_token");
-    if (error?.response) {
-      const statusCode = error.response?.status;
-      if (statusCode === 422) {
-        throw new ValidationError(error.response.data);
-      } else if (statusCode >= 400) {
-        if (statusCode === 401) {
-          Cookies.remove("auth_token");
-          if (token) {
-            window.location.reload();
-          }
-        }
-      }
-      errorHandler(error);
+  (res) => res,
+  async (error) => {
+    const status = error?.response?.status;
+    const original = error?.config as
+      | (InternalAxiosRequestConfig & { _retry?: boolean })
+      | undefined;
+
+    if (status === 422) {
+      throw new ValidationError(error.response.data);
     }
+
+    // On an expired access token, try to refresh once, then replay the request.
+    if (
+      status === 401 &&
+      original &&
+      !original._retry &&
+      !original.url?.includes("/refresh")
+    ) {
+      original._retry = true;
+      const newToken = await refreshAccessToken();
+      if (newToken) {
+        original.headers.Authorization = `Bearer ${newToken}`;
+        return httpService(original);
+      }
+      clearAuthTokens();
+      if (typeof window !== "undefined") window.location.assign("/login");
+    }
+
+    if (error?.response) {
+      errorHandler(error); // throws ApiError
+    }
+    return Promise.reject(error);
   }
 );
 
@@ -51,3 +109,14 @@ export const createData = httpService.post;
 export const updateData = httpService.put;
 export const updateDataPartially = httpService.patch;
 export const deleteData = httpService.delete;
+
+/** Revoke the refresh token server-side, then clear local auth. */
+export async function logout() {
+  const refreshToken = Cookies.get(REFRESH_COOKIE);
+  try {
+    if (refreshToken) await axios.post(`${API_URL}/logout`, { refreshToken });
+  } catch {
+    /* best-effort; clear locally regardless */
+  }
+  clearAuthTokens();
+}

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -1,8 +1,8 @@
 import { Link } from "react-router";
 
-import AuthLoginForm from "@/components/forms/AuhtLoginForm";
+import AuthSignupForm from "@/components/forms/AuthSignupForm";
 
-const LoginPage = () => {
+const SignupPage = () => {
   return (
     <main className="w-full h-svh md:flex-row flex-col flex items-center justify-center bg-white">
       <div className="bg-success-darker w-full px-12 flex flex-col items-center justify-center h-1/3 md:order-1 md:h-full">
@@ -34,18 +34,18 @@ const LoginPage = () => {
             </h6>
           </div>
 
-          <h4>Welcome Back!</h4>
+          <h4>Create your account</h4>
           <p>
-            Sign in to have access to your content creation dashboard and
-            innovate the world
+            Set up your content workspace and start publishing to your website
+            in minutes.
           </p>
 
-          <AuthLoginForm />
+          <AuthSignupForm />
 
           <p className="text-m-body2 md:text-d-body2">
-            Don&apos;t have an account?{" "}
-            <Link to="/sign-up" className="text-success-darker font-semibold">
-              Sign up
+            Already have an account?{" "}
+            <Link to="/login" className="text-success-darker font-semibold">
+              Log in
             </Link>
           </p>
         </div>
@@ -54,4 +54,4 @@ const LoginPage = () => {
   );
 };
 
-export default LoginPage;
+export default SignupPage;

--- a/frontend/src/services/authentication/useLogin.ts
+++ b/frontend/src/services/authentication/useLogin.ts
@@ -1,5 +1,4 @@
-import Cookies from "js-cookie";
-import { createData } from "@/core/http-service";
+import { createData, setAuthTokens, type AuthTokens } from "@/core/http-service";
 import { useMutation } from "@tanstack/react-query";
 import toast from "react-hot-toast";
 import { useNavigate } from "react-router";
@@ -9,10 +8,8 @@ interface ILoginCredentialsProps {
   password: string;
 }
 
-interface ILoginResponseProps {
+interface ILoginResponseProps extends AuthTokens {
   message: string;
-  token: string;
-  expiresAt: string;
 }
 
 const loginHandler = async (data: ILoginCredentialsProps) => {
@@ -29,9 +26,7 @@ export const useLoginHandler = () => {
     onSuccess: (response) => {
       if (response?.data?.token) {
         toast.success(response?.data?.message);
-        Cookies.set("auth_token", response?.data?.token, {
-          expires: new Date(response?.data?.expiresAt),
-        });
+        setAuthTokens(response.data);
 
         // redirect the user
         navigate("/", {

--- a/frontend/src/services/authentication/useSignup.ts
+++ b/frontend/src/services/authentication/useSignup.ts
@@ -1,0 +1,36 @@
+import { createData } from "@/core/http-service";
+import { useMutation } from "@tanstack/react-query";
+import toast from "react-hot-toast";
+import { useNavigate } from "react-router";
+
+interface ISignupCredentialsProps {
+  first_name: string;
+  last_name: string;
+  email: string;
+  password: string;
+}
+
+const signupHandler = async (data: ISignupCredentialsProps) => {
+  return await createData<{ message: string }>(`/sign-up`, data);
+};
+
+export const useSignupHandler = () => {
+  const navigate = useNavigate();
+
+  const mutation = useMutation({
+    mutationKey: ["signup-user"],
+    mutationFn: signupHandler,
+    onSuccess: (response) => {
+      toast.success(response?.data?.message ?? "Account created. Please log in.");
+      navigate("/login", { replace: true });
+    },
+    onError: (error) => {
+      toast(error?.message);
+    },
+  });
+
+  return {
+    isSigningUp: mutation?.isPending,
+    signupHandler: mutation?.mutate,
+  };
+};

--- a/frontend/src/types/forms/auth.validations.ts
+++ b/frontend/src/types/forms/auth.validations.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
-import { EMAIL_FIELD, PASSWORD_FIELD } from "./index.schema";
+import {
+  EMAIL_FIELD,
+  NAME_FIELD,
+  PASSWORD_FIELD,
+  STRONG_PASSWORD_FIELD,
+} from "./index.schema";
 
 export const loginFormSchema = z.object({
   email: EMAIL_FIELD,
@@ -7,3 +12,12 @@ export const loginFormSchema = z.object({
 });
 
 export type TLoginForm = z.infer<typeof loginFormSchema>;
+
+export const signupFormSchema = z.object({
+  first_name: NAME_FIELD,
+  last_name: NAME_FIELD,
+  email: EMAIL_FIELD,
+  password: STRONG_PASSWORD_FIELD,
+});
+
+export type TSignupForm = z.infer<typeof signupFormSchema>;

--- a/frontend/src/types/forms/index.schema.ts
+++ b/frontend/src/types/forms/index.schema.ts
@@ -26,3 +26,17 @@ export const PASSWORD_FIELD = z
     message: VALIDATION_MESSAGES.password.maximum,
   })
   .nonempty(VALIDATION_MESSAGES.password.required);
+
+// Signup password: mirrors the backend's strength rules.
+export const STRONG_PASSWORD_FIELD = PASSWORD_FIELD.regex(/[A-Z]/, {
+  message: "Password must contain at least one capital letter",
+})
+  .regex(/\d/, { message: "Password must contain at least one number" })
+  .regex(/[!@#$%^&*(),.?":{}|<>]/, {
+    message: "Password must contain at least one special character",
+  });
+
+export const NAME_FIELD = z
+  .string({ message: "This field is required" })
+  .trim()
+  .min(3, { message: "Must be at least 3 characters" });


### PR DESCRIPTION
Backend:
- Rotating, revocable refresh tokens. New RefreshToken model (only a SHA-256 hash stored) + migration. login now returns { token, expiresAt, refreshToken, refreshExpiresAt }; access token shortened to 1h, refresh 30d.
- New POST /refresh (validate + rotate → new access + refresh) and POST /logout (revoke). Token helpers in utils/tokens.ts.
- Signup now generates a unique, URL-safe username (slugified, deduped) instead of the collision-prone "first_last_".
- Fail-fast startup check for JWT_SECRET_KEY + DATABASE_URL.

Frontend:
- Signup page + form wired to POST /sign-up (zod validation mirrors backend), with login<->signup cross-links.
- http-service stores both tokens; response interceptor transparently refreshes on 401 (single-flight) and replays the request, else clears + routes to login.
- Logout now revokes the refresh token server-side.

Apply the migration locally: cd backend && npx prisma migrate deploy (or `migrate dev` in development).