### PR TITLE
feat(p3+p4): blog series + tags

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -9,6 +9,8 @@ import { router as blogRouter } from "./src/routes/blog.js";
 import { router as mediaFileRouter } from "./src/routes/media-file.js";
 import { router as projectRouter } from "./src/routes/projects.js";
 import { router as profileRouter } from "./src/routes/profile.js";
+import { router as seriesRouter } from "./src/routes/series.js";
+import { router as tagRouter } from "./src/routes/tags.js";
 import { ICustomError } from "./src/types/index.js";
 
 // make sure __dirname is defined for ES modules
@@ -66,6 +68,8 @@ app.use(blogRouter);
 app.use(projectRouter);
 app.use(mediaFileRouter);
 app.use(profileRouter);
+app.use(seriesRouter);
+app.use(tagRouter);
 
 app.get("/", (req, res) => {
   res.status(200).json({

--- a/backend/prisma/migrations/20251016000000_add_series_and_tags/migration.sql
+++ b/backend/prisma/migrations/20251016000000_add_series_and_tags/migration.sql
@@ -1,0 +1,85 @@
+-- AlterTable
+ALTER TABLE "public"."Blog" ADD COLUMN     "seriesId" INTEGER,
+ADD COLUMN     "series_order" INTEGER;
+
+-- CreateTable
+CREATE TABLE "public"."Series" (
+    "id" SERIAL NOT NULL,
+    "title" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "description" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "userId" INTEGER NOT NULL,
+
+    CONSTRAINT "Series_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Tag" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "userId" INTEGER NOT NULL,
+
+    CONSTRAINT "Tag_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."_BlogToTag" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL,
+
+    CONSTRAINT "_BlogToTag_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateTable
+CREATE TABLE "public"."_ProjectToTag" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL,
+
+    CONSTRAINT "_ProjectToTag_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE INDEX "Series_userId_idx" ON "public"."Series"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Series_userId_slug_key" ON "public"."Series"("userId", "slug");
+
+-- CreateIndex
+CREATE INDEX "Tag_userId_idx" ON "public"."Tag"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Tag_userId_slug_key" ON "public"."Tag"("userId", "slug");
+
+-- CreateIndex
+CREATE INDEX "_BlogToTag_B_index" ON "public"."_BlogToTag"("B");
+
+-- CreateIndex
+CREATE INDEX "_ProjectToTag_B_index" ON "public"."_ProjectToTag"("B");
+
+-- CreateIndex
+CREATE INDEX "Blog_seriesId_idx" ON "public"."Blog"("seriesId");
+
+-- AddForeignKey
+ALTER TABLE "public"."Series" ADD CONSTRAINT "Series_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Tag" ADD CONSTRAINT "Tag_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Blog" ADD CONSTRAINT "Blog_seriesId_fkey" FOREIGN KEY ("seriesId") REFERENCES "public"."Series"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."_BlogToTag" ADD CONSTRAINT "_BlogToTag_A_fkey" FOREIGN KEY ("A") REFERENCES "public"."Blog"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."_BlogToTag" ADD CONSTRAINT "_BlogToTag_B_fkey" FOREIGN KEY ("B") REFERENCES "public"."Tag"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."_ProjectToTag" ADD CONSTRAINT "_ProjectToTag_A_fkey" FOREIGN KEY ("A") REFERENCES "public"."Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."_ProjectToTag" ADD CONSTRAINT "_ProjectToTag_B_fkey" FOREIGN KEY ("B") REFERENCES "public"."Tag"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -26,6 +26,45 @@ model User {
   projects Project[]
   mediaFiles MediaFile[]
   refreshTokens RefreshToken[]
+  series Series[]
+  tags Tag[]
+}
+
+// A blog series groups ordered posts ("Part 1 of N"). A blog belongs to at
+// most one series; a series belongs to one user. Slugs are unique per user so
+// the public URL /public/:username/series/:slug resolves unambiguously.
+model Series {
+  id          Int      @id @default(autoincrement())
+  title       String
+  slug        String
+  description String?
+  created_at  DateTime @default(now())
+  updated_at  DateTime @updatedAt
+
+  userId Int
+  user   User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  blogs Blog[]
+
+  @@unique([userId, slug])
+  @@index([userId])
+}
+
+// Free-form labels shared across a user's blogs and projects. Scoped per user
+// (slug unique per user) so two authors can both have a "react" tag.
+model Tag {
+  id   Int    @id @default(autoincrement())
+  name String
+  slug String
+
+  userId Int
+  user   User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  blogs    Blog[]
+  projects Project[]
+
+  @@unique([userId, slug])
+  @@index([userId])
 }
 
 // Opaque, rotating refresh tokens (only a SHA-256 hash is stored).
@@ -59,9 +98,19 @@ model Blog {
 
   userId Int
   user   User @relation(fields: [userId], references: [id], onDelete: Cascade)
-  
+
   cover_imageId Int?
   cover_image   MediaFile? @relation(fields: [cover_imageId], references: [id])
+
+  // Optional membership in a series. series_order positions this post among its
+  // siblings (lower = earlier). SetNull keeps the blog if its series is deleted.
+  seriesId     Int?
+  series       Series? @relation(fields: [seriesId], references: [id], onDelete: SetNull)
+  series_order Int?
+
+  tags Tag[]
+
+  @@index([seriesId])
 }
 
 model Project {
@@ -82,7 +131,9 @@ model Project {
  // Relation to MediaFile
   cover_imageId Int?
   cover_image   MediaFile? @relation(fields: [cover_imageId], references: [id])
-} 
+
+  tags Tag[]
+}
 
 
 model MediaFile {

--- a/backend/src/controllers/blog.ts
+++ b/backend/src/controllers/blog.ts
@@ -8,6 +8,45 @@ import HTTP_STATUS_CODES from "../utils/statusCodes.js";
 import { extractPlainText } from "../utils/index.js";
 import { sanitizeRichTextContent } from "../utils/sanitize-html.js";
 import { deleteMediaFileById } from "./media-file.js";
+import { resolveTagConnections } from "./tags.js";
+import { buildSeriesContext } from "./series.js";
+
+// Validate that a series (when provided) belongs to the user, and normalize the
+// order. Returns the numeric id to connect (or null to detach) plus the order.
+async function resolveSeriesSelection(
+  userId: number,
+  seriesId: unknown,
+  seriesOrder: unknown
+): Promise<{ seriesId: number | null; series_order: number | null }> {
+  if (seriesId === undefined || seriesId === null || seriesId === "") {
+    return { seriesId: null, series_order: null };
+  }
+
+  const id = Number(seriesId);
+  if (!Number.isInteger(id)) {
+    const error = new CustomError("Invalid series selected.");
+    error.statusCode = HTTP_STATUS_CODES.StatusBadRequest;
+    throw error;
+  }
+
+  const series = await prisma.series.findFirst({ where: { id, userId } });
+  if (!series) {
+    const error = new CustomError("Selected series was not found.");
+    error.statusCode = HTTP_STATUS_CODES.StatusBadRequest;
+    throw error;
+  }
+
+  const orderNum = Number(seriesOrder);
+  const series_order =
+    seriesOrder === undefined ||
+    seriesOrder === null ||
+    seriesOrder === "" ||
+    Number.isNaN(orderNum)
+      ? null
+      : orderNum;
+
+  return { seriesId: id, series_order };
+}
 
 export const getAllBlogsHandler = async (
   req: Request,
@@ -20,7 +59,11 @@ export const getAllBlogsHandler = async (
   try {
     const allBlogs = await prisma.blog.findMany({
       where: { userId: userId },
-      include: { cover_image: true }, // include relation
+      include: {
+        cover_image: true, // include relation
+        series: { select: { id: true, title: true, slug: true } },
+        tags: { select: { name: true } },
+      },
     });
 
     if (!allBlogs) {
@@ -44,6 +87,9 @@ export const getAllBlogsHandler = async (
       is_draft: blogItem?.is_draft,
       reading_time: blogItem?.reading_time,
       is_featured: blogItem?.is_featured,
+      series: blogItem?.series || null,
+      series_order: blogItem?.series_order,
+      tags: blogItem?.tags.map((tag) => tag.name),
     }));
 
     res.status(HTTP_STATUS_CODES.StatusOk).json({
@@ -68,7 +114,11 @@ export const getSingleBlogHandler = async (
     // check if the blog with that id exists
     const blogDoc = await prisma.blog.findUnique({
       where: { id: blogId, userId },
-      include: { cover_image: true },
+      include: {
+        cover_image: true,
+        series: { select: { id: true, title: true, slug: true } },
+        tags: { select: { name: true } },
+      },
     });
 
     if (!blogDoc) {
@@ -91,6 +141,10 @@ export const getSingleBlogHandler = async (
       views_count: blogDoc?.views_count,
       likes_count: blogDoc?.likes_count,
       is_featured: blogDoc?.is_featured,
+      seriesId: blogDoc?.seriesId,
+      series: blogDoc?.series || null,
+      series_order: blogDoc?.series_order,
+      tags: blogDoc?.tags.map((tag) => tag.name),
     };
 
     res.status(HTTP_STATUS_CODES.StatusOk).json({
@@ -116,6 +170,7 @@ export const createBlogHandler = async (
     cover_image,
     content,
     is_featured,
+    tags,
   } = req.body;
 
   try {
@@ -152,6 +207,13 @@ export const createBlogHandler = async (
 
     const sanitizedContent = sanitizeRichTextContent(content);
 
+    const selection = await resolveSeriesSelection(
+      userId,
+      req.body.seriesId,
+      req.body.series_order
+    );
+    const tagConnections = await resolveTagConnections(userId, tags);
+
     // create blog content
     const newBlog = {
       title,
@@ -164,10 +226,15 @@ export const createBlogHandler = async (
       likes_count: 0,
       is_draft: true,
       reading_time: stats?.minutes,
+      series_order: selection.series_order,
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
       user: { connect: { id: userId } },
       cover_image: cover_image ? { connect: { url: cover_image } } : undefined,
+      series: selection.seriesId
+        ? { connect: { id: selection.seriesId } }
+        : undefined,
+      tags: tagConnections.length ? { connect: tagConnections } : undefined,
     };
 
     const result = await prisma.blog.create({
@@ -206,6 +273,7 @@ export const updateBlogHandler = async (
     cover_image,
     content,
     is_featured,
+    tags,
   } = req.body;
 
   try {
@@ -232,6 +300,13 @@ export const updateBlogHandler = async (
     const sanitizedContent = sanitizeRichTextContent(content);
     const oldCoverImageId = blog.cover_imageId;
 
+    const selection = await resolveSeriesSelection(
+      userId,
+      req.body.seriesId,
+      req.body.series_order
+    );
+    const tagConnections = await resolveTagConnections(userId, tags);
+
     const updatedContent = {
       title,
       short_description,
@@ -240,7 +315,14 @@ export const updateBlogHandler = async (
       cover_image,
       reading_time,
       is_featured,
+      series_order: selection.series_order,
       updated_at: new Date(),
+      // connect to the chosen series, or detach if none was selected
+      series: selection.seriesId
+        ? { connect: { id: selection.seriesId } }
+        : { disconnect: true },
+      // `set` replaces the full tag list; an empty array clears all tags
+      tags: { set: tagConnections },
     };
 
     if (cover_image) {
@@ -391,6 +473,8 @@ export const getPublishedBlogsHandler = async (
   next: NextFunction
 ) => {
   const username = req.params.username;
+  const tagSlug =
+    typeof req.query.tag === "string" ? req.query.tag : undefined;
 
   try {
     const allBlogs = await prisma.blog.findMany({
@@ -399,9 +483,14 @@ export const getPublishedBlogsHandler = async (
         user: {
           username,
         },
+        // optional tag filter: /public/:username/blog?tag=react
+        ...(tagSlug ? { tags: { some: { slug: tagSlug } } } : {}),
       },
+      orderBy: { published_at: "desc" },
       include: {
         cover_image: true,
+        series: { select: { title: true, slug: true } },
+        tags: { select: { name: true, slug: true } },
         user: {
           select: { username: true, first_name: true, last_name: true },
         },
@@ -425,6 +514,8 @@ export const getPublishedBlogsHandler = async (
       created_at: b.created_at,
       published_at: b.published_at,
       author: b.user.username, // include for public display
+      series: b.series || null,
+      tags: b.tags,
     }));
 
     res.status(HTTP_STATUS_CODES.StatusOk).json({
@@ -454,6 +545,7 @@ export const getPublishedSingleBlogHandler = async (
       },
       include: {
         cover_image: true,
+        tags: { select: { name: true, slug: true } },
         user: {
           select: { username: true, first_name: true, last_name: true },
         },
@@ -471,6 +563,9 @@ export const getPublishedSingleBlogHandler = async (
       data: { views_count: { increment: 1 } },
     });
 
+    // "Part N of M" + prev/next navigation when this post belongs to a series.
+    const series = await buildSeriesContext(blogDoc);
+
     const formattedBlog = {
       id: blogDoc.id,
       slug: blogDoc.slug,
@@ -483,6 +578,8 @@ export const getPublishedSingleBlogHandler = async (
       reading_time: blogDoc.reading_time,
       published_at: blogDoc.published_at,
       author: blogDoc.user.username,
+      series,
+      tags: blogDoc.tags,
     };
 
     res.status(HTTP_STATUS_CODES.StatusOk).json({

--- a/backend/src/controllers/projects.ts
+++ b/backend/src/controllers/projects.ts
@@ -7,6 +7,7 @@ import CustomError from "../utils/customError.js";
 import HTTP_STATUS_CODES from "../utils/statusCodes.js";
 import { sanitizeRichTextContent } from "../utils/sanitize-html.js";
 import { deleteMediaFileById } from "./media-file.js";
+import { resolveTagConnections } from "./tags.js";
 
 export const getAllProjectsHandler = async (
   req: Request,
@@ -21,7 +22,10 @@ export const getAllProjectsHandler = async (
       where: {
         userId: userId,
       },
-      include: { cover_image: true },
+      include: {
+        cover_image: true,
+        tags: { select: { name: true } },
+      },
     });
 
     if (!allProjects) {
@@ -41,6 +45,7 @@ export const getAllProjectsHandler = async (
       updated_at: item?.updated_at,
       published_at: item?.published_at,
       is_featured: item?.is_featured,
+      tags: item?.tags.map((tag) => tag.name),
     }));
 
     res.status(HTTP_STATUS_CODES.StatusOk).json({
@@ -68,7 +73,10 @@ export const getSingleProjectHandler = async (
         id: +projectId,
         userId: userId,
       },
-      include: { cover_image: true },
+      include: {
+        cover_image: true,
+        tags: { select: { name: true } },
+      },
     });
 
     if (!projectDoc) {
@@ -89,6 +97,7 @@ export const getSingleProjectHandler = async (
       published_at: projectDoc?.published_at,
       is_draft: projectDoc?.is_draft,
       is_featured: projectDoc?.is_featured,
+      tags: projectDoc?.tags.map((tag) => tag.name),
     };
 
     res.status(HTTP_STATUS_CODES.StatusOk).json({
@@ -114,6 +123,7 @@ export const createProjectHandler = async (
     content,
     cover_image,
     is_featured,
+    tags,
   } = req.body;
 
   try {
@@ -145,6 +155,7 @@ export const createProjectHandler = async (
     }
 
     const sanitizedContent = sanitizeRichTextContent(content);
+    const tagConnections = await resolveTagConnections(userId, tags);
 
     const newProject = {
       title,
@@ -158,6 +169,7 @@ export const createProjectHandler = async (
       updated_at: new Date().toISOString(),
       user: { connect: { id: userId } },
       cover_image: cover_image ? { connect: { url: cover_image } } : undefined,
+      tags: tagConnections.length ? { connect: tagConnections } : undefined,
     };
 
     const result = await prisma.project.create({
@@ -196,6 +208,7 @@ export const updateProjectHandler = async (
     content,
     cover_image,
     is_featured,
+    tags,
   } = req.body;
 
   try {
@@ -215,6 +228,7 @@ export const updateProjectHandler = async (
 
     const sanitizedContent = sanitizeRichTextContent(content);
     const oldCoverImageId = projectDoc.cover_imageId;
+    const tagConnections = await resolveTagConnections(userId, tags);
 
     const updatedContent = {
       title,
@@ -224,6 +238,8 @@ export const updateProjectHandler = async (
       cover_image,
       is_featured,
       updated_at: new Date(),
+      // `set` replaces the full tag list; an empty array clears all tags
+      tags: { set: tagConnections },
     };
 
     if (cover_image) {
@@ -376,6 +392,8 @@ export const getPublishedProjectHandler = async (
   next: NextFunction
 ) => {
   const username = req.params.username;
+  const tagSlug =
+    typeof req.query.tag === "string" ? req.query.tag : undefined;
 
   try {
     const allPublishedProjects = await prisma.project.findMany({
@@ -384,9 +402,13 @@ export const getPublishedProjectHandler = async (
         user: {
           username,
         },
+        // optional tag filter: /public/:username/project?tag=react
+        ...(tagSlug ? { tags: { some: { slug: tagSlug } } } : {}),
       },
+      orderBy: { published_at: "desc" },
       include: {
         cover_image: true,
+        tags: { select: { name: true, slug: true } },
         user: true,
       },
     });
@@ -408,6 +430,7 @@ export const getPublishedProjectHandler = async (
       updated_at: item.updated_at,
       published_at: item.published_at,
       is_draft: item.is_draft,
+      tags: item.tags,
     }));
 
     res.status(HTTP_STATUS_CODES.StatusOk).json({
@@ -434,7 +457,11 @@ export const getPublishedSingleProjectHandler = async (
         is_draft: false,
         user: { username },
       },
-      include: { cover_image: true, user: true },
+      include: {
+        cover_image: true,
+        tags: { select: { name: true, slug: true } },
+        user: true,
+      },
     });
 
     if (!projectDoc) {
@@ -454,6 +481,7 @@ export const getPublishedSingleProjectHandler = async (
       updated_at: projectDoc.updated_at,
       published_at: projectDoc.published_at,
       is_draft: projectDoc.is_draft,
+      tags: projectDoc.tags,
     };
 
     res.status(HTTP_STATUS_CODES.StatusOk).json({

--- a/backend/src/controllers/series.ts
+++ b/backend/src/controllers/series.ts
@@ -1,0 +1,331 @@
+import { NextFunction, Response, Request } from "express";
+import { Prisma } from "@prisma/client";
+
+import prisma from "../prisma.js";
+import CustomError from "../utils/customError.js";
+import HTTP_STATUS_CODES from "../utils/statusCodes.js";
+import { toSlug } from "../utils/slug.js";
+
+// Order siblings within a series: author-assigned order first (nulls last),
+// then id as a stable tie-breaker. Shared by every series read path.
+const SERIES_ORDER: Prisma.BlogOrderByWithRelationInput[] = [
+  { series_order: { sort: "asc", nulls: "last" } },
+  { id: "asc" },
+];
+
+/**
+ * Build the "Part N of M" navigation context for a published blog that belongs
+ * to a series. Returns null when the blog has no series. Only *published*
+ * siblings are counted/listed, so the public numbering is gap-free.
+ */
+export async function buildSeriesContext(blog: {
+  id: number;
+  seriesId: number | null;
+}) {
+  if (!blog.seriesId) return null;
+
+  const series = await prisma.series.findUnique({
+    where: { id: blog.seriesId },
+  });
+  if (!series) return null;
+
+  const siblings = await prisma.blog.findMany({
+    where: { seriesId: blog.seriesId, is_draft: false },
+    orderBy: SERIES_ORDER,
+    select: { id: true, title: true, slug: true },
+  });
+
+  const index = siblings.findIndex((s) => s.id === blog.id);
+  const parts = siblings.map((s, i) => ({
+    id: s.id,
+    title: s.title,
+    slug: s.slug,
+    order: i + 1,
+    is_current: s.id === blog.id,
+  }));
+
+  const neighbor = (s: (typeof siblings)[number]) => ({
+    id: s.id,
+    title: s.title,
+    slug: s.slug,
+  });
+
+  return {
+    id: series.id,
+    title: series.title,
+    slug: series.slug,
+    description: series.description,
+    part: index >= 0 ? index + 1 : null,
+    total: siblings.length,
+    parts,
+    prev: index > 0 ? neighbor(siblings[index - 1]) : null,
+    next:
+      index >= 0 && index < siblings.length - 1
+        ? neighbor(siblings[index + 1])
+        : null,
+  };
+}
+
+export const getAllSeriesHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  // @ts-ignore
+  const userId = req?.userId;
+
+  try {
+    const series = await prisma.series.findMany({
+      where: { userId },
+      orderBy: { created_at: "desc" },
+      include: { _count: { select: { blogs: true } } },
+    });
+
+    const formatted = series.map((item) => ({
+      id: item.id,
+      title: item.title,
+      slug: item.slug,
+      description: item.description,
+      created_at: item.created_at,
+      updated_at: item.updated_at,
+      blogs_count: item._count.blogs,
+    }));
+
+    res.status(HTTP_STATUS_CODES.StatusOk).json({
+      message: "successful",
+      data: formatted,
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const getSingleSeriesHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  // @ts-ignore
+  const userId = req?.userId;
+  const seriesId = parseInt(req.params.id);
+
+  try {
+    const series = await prisma.series.findFirst({
+      where: { id: seriesId, userId },
+      include: {
+        blogs: {
+          orderBy: SERIES_ORDER,
+          select: {
+            id: true,
+            title: true,
+            slug: true,
+            series_order: true,
+            is_draft: true,
+          },
+        },
+      },
+    });
+
+    if (!series) {
+      const error = new CustomError("No series was found.");
+      error.statusCode = HTTP_STATUS_CODES.StatusNotFound;
+      throw error;
+    }
+
+    res.status(HTTP_STATUS_CODES.StatusOk).json({
+      message: "successful",
+      data: {
+        id: series.id,
+        title: series.title,
+        slug: series.slug,
+        description: series.description,
+        created_at: series.created_at,
+        updated_at: series.updated_at,
+        blogs: series.blogs,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const createSeriesHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  // @ts-ignore
+  const userId = req?.userId;
+  const { title, description } = req.body;
+
+  try {
+    const slug = toSlug(title);
+    if (!slug) {
+      const error = new CustomError("Series title is invalid.");
+      error.statusCode = HTTP_STATUS_CODES.StatusBadRequest;
+      throw error;
+    }
+
+    const existing = await prisma.series.findUnique({
+      where: { userId_slug: { userId, slug } },
+    });
+    if (existing) {
+      const error = new CustomError(
+        "A series with the same title already exists. Please use a different title."
+      );
+      error.statusCode = HTTP_STATUS_CODES.StatusBadRequest;
+      throw error;
+    }
+
+    const series = await prisma.series.create({
+      data: { title: title.trim(), slug, description: description || null, userId },
+    });
+
+    res.status(HTTP_STATUS_CODES.StatusCreated).json({
+      message: "Series was created successfully",
+      data: { id: series.id, title: series.title, slug: series.slug },
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const updateSeriesHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  // @ts-ignore
+  const userId = req?.userId;
+  const seriesId = parseInt(req.params.id);
+  const { title, description } = req.body;
+
+  try {
+    const series = await prisma.series.findFirst({
+      where: { id: seriesId, userId },
+    });
+    if (!series) {
+      const error = new CustomError("No series was found.");
+      error.statusCode = HTTP_STATUS_CODES.StatusNotFound;
+      throw error;
+    }
+
+    const slug = toSlug(title);
+    if (!slug) {
+      const error = new CustomError("Series title is invalid.");
+      error.statusCode = HTTP_STATUS_CODES.StatusBadRequest;
+      throw error;
+    }
+
+    const clash = await prisma.series.findUnique({
+      where: { userId_slug: { userId, slug } },
+    });
+    if (clash && clash.id !== seriesId) {
+      const error = new CustomError(
+        "A series with the same title already exists. Please use a different title."
+      );
+      error.statusCode = HTTP_STATUS_CODES.StatusBadRequest;
+      throw error;
+    }
+
+    const updated = await prisma.series.update({
+      where: { id: seriesId },
+      data: { title: title.trim(), slug, description: description ?? null },
+    });
+
+    res.status(HTTP_STATUS_CODES.StatusOk).json({
+      message: "Series was updated successfully",
+      data: { id: updated.id, title: updated.title, slug: updated.slug },
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const deleteSeriesHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  // @ts-ignore
+  const userId = req?.userId;
+  const seriesId = parseInt(req.params.id);
+
+  try {
+    const series = await prisma.series.findFirst({
+      where: { id: seriesId, userId },
+    });
+    if (!series) {
+      const error = new CustomError("No series was found.");
+      error.statusCode = HTTP_STATUS_CODES.StatusNotFound;
+      throw error;
+    }
+
+    // Member blogs keep existing; their seriesId is set NULL via the FK rule.
+    await prisma.series.delete({ where: { id: seriesId } });
+
+    res.status(HTTP_STATUS_CODES.StatusOk).json({
+      message: "Series was deleted successfully",
+      data: [],
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+// ------------------- public api handler -----------------------
+// Returns a series with its ordered, published parts — lets a consumer render a
+// series landing page at /public/:username/series/:slug.
+export const getPublicSeriesHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const username = req.params.username;
+  const slug = req.params.slug;
+
+  try {
+    const series = await prisma.series.findFirst({
+      where: { slug, user: { username } },
+      include: {
+        blogs: {
+          where: { is_draft: false },
+          orderBy: SERIES_ORDER,
+          include: { cover_image: true },
+        },
+      },
+    });
+
+    if (!series) {
+      const error = new CustomError("No series was found.");
+      error.statusCode = HTTP_STATUS_CODES.StatusNotFound;
+      throw error;
+    }
+
+    const parts = series.blogs.map((blog, index) => ({
+      part: index + 1,
+      id: blog.id,
+      title: blog.title,
+      slug: blog.slug,
+      short_description: blog.short_description,
+      description: blog.description,
+      cover_image: blog.cover_image?.url || null,
+      reading_time: blog.reading_time,
+      published_at: blog.published_at,
+    }));
+
+    res.status(HTTP_STATUS_CODES.StatusOk).json({
+      message: "successful",
+      data: {
+        id: series.id,
+        title: series.title,
+        slug: series.slug,
+        description: series.description,
+        total: parts.length,
+        parts,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/controllers/tags.ts
+++ b/backend/src/controllers/tags.ts
@@ -1,0 +1,235 @@
+import { NextFunction, Response, Request } from "express";
+
+import prisma from "../prisma.js";
+import CustomError from "../utils/customError.js";
+import HTTP_STATUS_CODES from "../utils/statusCodes.js";
+import { toSlug } from "../utils/slug.js";
+
+/**
+ * Upsert the given tag names for a user and return a relation-connect list.
+ * Names are de-duplicated by slug; blank/invalid names are skipped. Pass the
+ * result to Prisma's `tags: { set: [...] }` on a blog or project.
+ */
+export async function resolveTagConnections(
+  userId: number,
+  names: unknown
+): Promise<{ id: number }[]> {
+  if (!Array.isArray(names)) return [];
+
+  // slug -> display name (first occurrence wins, so "React" beats a later "react")
+  const bySlug = new Map<string, string>();
+  for (const raw of names) {
+    if (typeof raw !== "string") continue;
+    const name = raw.trim();
+    const slug = toSlug(name);
+    if (!slug) continue;
+    if (!bySlug.has(slug)) bySlug.set(slug, name);
+  }
+
+  const connections: { id: number }[] = [];
+  for (const [slug, name] of bySlug) {
+    const tag = await prisma.tag.upsert({
+      where: { userId_slug: { userId, slug } },
+      create: { name, slug, userId },
+      update: {}, // keep the existing display name when the tag is re-used
+    });
+    connections.push({ id: tag.id });
+  }
+  return connections;
+}
+
+export const getAllTagsHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  // @ts-ignore
+  const userId = req?.userId;
+
+  try {
+    const tags = await prisma.tag.findMany({
+      where: { userId },
+      orderBy: { name: "asc" },
+      include: { _count: { select: { blogs: true, projects: true } } },
+    });
+
+    const formatted = tags.map((tag) => ({
+      id: tag.id,
+      name: tag.name,
+      slug: tag.slug,
+      blogs_count: tag._count.blogs,
+      projects_count: tag._count.projects,
+    }));
+
+    res.status(HTTP_STATUS_CODES.StatusOk).json({
+      message: "successful",
+      data: formatted,
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const createTagHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  // @ts-ignore
+  const userId = req?.userId;
+  const { name } = req.body;
+
+  try {
+    const slug = toSlug(name);
+    if (!slug) {
+      const error = new CustomError("Tag name is invalid.");
+      error.statusCode = HTTP_STATUS_CODES.StatusBadRequest;
+      throw error;
+    }
+
+    const existing = await prisma.tag.findUnique({
+      where: { userId_slug: { userId, slug } },
+    });
+    if (existing) {
+      const error = new CustomError("A tag with that name already exists.");
+      error.statusCode = HTTP_STATUS_CODES.StatusBadRequest;
+      throw error;
+    }
+
+    const tag = await prisma.tag.create({
+      data: { name: name.trim(), slug, userId },
+    });
+
+    res.status(HTTP_STATUS_CODES.StatusCreated).json({
+      message: "Tag was created successfully",
+      data: { id: tag.id, name: tag.name, slug: tag.slug },
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const updateTagHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  // @ts-ignore
+  const userId = req?.userId;
+  const tagId = parseInt(req.params.id);
+  const { name } = req.body;
+
+  try {
+    const tag = await prisma.tag.findFirst({ where: { id: tagId, userId } });
+    if (!tag) {
+      const error = new CustomError("No tag was found.");
+      error.statusCode = HTTP_STATUS_CODES.StatusNotFound;
+      throw error;
+    }
+
+    const slug = toSlug(name);
+    if (!slug) {
+      const error = new CustomError("Tag name is invalid.");
+      error.statusCode = HTTP_STATUS_CODES.StatusBadRequest;
+      throw error;
+    }
+
+    // Renaming onto an existing tag's slug would violate the unique constraint.
+    const clash = await prisma.tag.findUnique({
+      where: { userId_slug: { userId, slug } },
+    });
+    if (clash && clash.id !== tagId) {
+      const error = new CustomError("A tag with that name already exists.");
+      error.statusCode = HTTP_STATUS_CODES.StatusBadRequest;
+      throw error;
+    }
+
+    const updated = await prisma.tag.update({
+      where: { id: tagId },
+      data: { name: name.trim(), slug },
+    });
+
+    res.status(HTTP_STATUS_CODES.StatusOk).json({
+      message: "Tag was updated successfully",
+      data: { id: updated.id, name: updated.name, slug: updated.slug },
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const deleteTagHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  // @ts-ignore
+  const userId = req?.userId;
+  const tagId = parseInt(req.params.id);
+
+  try {
+    const tag = await prisma.tag.findFirst({ where: { id: tagId, userId } });
+    if (!tag) {
+      const error = new CustomError("No tag was found.");
+      error.statusCode = HTTP_STATUS_CODES.StatusNotFound;
+      throw error;
+    }
+
+    // Join-table rows are removed automatically (FK ON DELETE CASCADE); the
+    // blogs/projects themselves are untouched.
+    await prisma.tag.delete({ where: { id: tagId } });
+
+    res.status(HTTP_STATUS_CODES.StatusOk).json({
+      message: "Tag was deleted successfully",
+      data: [],
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+// ------------------- public api handler -----------------------
+// Lists a user's tags that are attached to at least one *published* item, with
+// published-only usage counts — handy for a public tag cloud / filter UI.
+export const getPublicTagsHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const username = req.params.username;
+
+  try {
+    const tags = await prisma.tag.findMany({
+      where: {
+        user: { username },
+        OR: [
+          { blogs: { some: { is_draft: false } } },
+          { projects: { some: { is_draft: false } } },
+        ],
+      },
+      orderBy: { name: "asc" },
+      include: {
+        _count: {
+          select: {
+            blogs: { where: { is_draft: false } },
+            projects: { where: { is_draft: false } },
+          },
+        },
+      },
+    });
+
+    const formatted = tags.map((tag) => ({
+      name: tag.name,
+      slug: tag.slug,
+      blogs_count: tag._count.blogs,
+      projects_count: tag._count.projects,
+    }));
+
+    res.status(HTTP_STATUS_CODES.StatusOk).json({
+      message: "successful",
+      data: formatted,
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/routes/series.ts
+++ b/backend/src/routes/series.ts
@@ -1,0 +1,67 @@
+import express from "express";
+import { body } from "express-validator";
+import rateLimit from "express-rate-limit";
+
+import { errorValidator } from "../middlewares/validator.js";
+import { isAuthenticatedValidator } from "../middlewares/isAuth.js";
+
+import {
+  createSeriesHandler,
+  deleteSeriesHandler,
+  getAllSeriesHandler,
+  getPublicSeriesHandler,
+  getSingleSeriesHandler,
+  updateSeriesHandler,
+} from "../controllers/series.js";
+
+const router = express.Router();
+
+const seriesLimiter = rateLimit({
+  windowMs: 10 * 60 * 1000, // 10 minutes
+  max: 30,
+  message: {
+    message: "Too many requests. Please try again later.",
+  },
+});
+
+const titleValidator = [
+  body("title")
+    .trim()
+    .notEmpty()
+    .withMessage("title is required")
+    .isLength({ min: 3 })
+    .withMessage("title should be at least 3 characters"),
+];
+
+router.get("/series", isAuthenticatedValidator, getAllSeriesHandler);
+router.get("/series/:id", isAuthenticatedValidator, getSingleSeriesHandler);
+
+router.post(
+  "/series",
+  seriesLimiter,
+  isAuthenticatedValidator,
+  titleValidator,
+  errorValidator,
+  createSeriesHandler
+);
+
+router.put(
+  "/series/:id",
+  seriesLimiter,
+  isAuthenticatedValidator,
+  titleValidator,
+  errorValidator,
+  updateSeriesHandler
+);
+
+router.delete(
+  "/series/:id",
+  seriesLimiter,
+  isAuthenticatedValidator,
+  deleteSeriesHandler
+);
+
+// public api routes:
+router.get("/public/:username/series/:slug", getPublicSeriesHandler);
+
+export { router };

--- a/backend/src/routes/tags.ts
+++ b/backend/src/routes/tags.ts
@@ -1,0 +1,60 @@
+import express from "express";
+import { body } from "express-validator";
+import rateLimit from "express-rate-limit";
+
+import { errorValidator } from "../middlewares/validator.js";
+import { isAuthenticatedValidator } from "../middlewares/isAuth.js";
+
+import {
+  createTagHandler,
+  deleteTagHandler,
+  getAllTagsHandler,
+  getPublicTagsHandler,
+  updateTagHandler,
+} from "../controllers/tags.js";
+
+const router = express.Router();
+
+const tagLimiter = rateLimit({
+  windowMs: 10 * 60 * 1000, // 10 minutes
+  max: 60,
+  message: {
+    message: "Too many requests. Please try again later.",
+  },
+});
+
+const nameValidator = [
+  body("name")
+    .trim()
+    .notEmpty()
+    .withMessage("name is required")
+    .isLength({ min: 2 })
+    .withMessage("name should be at least 2 characters"),
+];
+
+router.get("/tag", isAuthenticatedValidator, getAllTagsHandler);
+
+router.post(
+  "/tag",
+  tagLimiter,
+  isAuthenticatedValidator,
+  nameValidator,
+  errorValidator,
+  createTagHandler
+);
+
+router.put(
+  "/tag/:id",
+  tagLimiter,
+  isAuthenticatedValidator,
+  nameValidator,
+  errorValidator,
+  updateTagHandler
+);
+
+router.delete("/tag/:id", tagLimiter, isAuthenticatedValidator, deleteTagHandler);
+
+// public api routes:
+router.get("/public/:username/tags", getPublicTagsHandler);
+
+export { router };

--- a/backend/src/utils/slug.ts
+++ b/backend/src/utils/slug.ts
@@ -1,0 +1,6 @@
+import slugify from "slugify";
+
+/** URL-safe slug: lowercase, ASCII-only, punctuation stripped. */
+export function toSlug(text: string): string {
+  return slugify.default(text ?? "", { lower: true, strict: true });
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ const UpdateBlogPage = lazy(() => import("./pages/UpdateBlog"));
 const ProjectPage = lazy(() => import("./pages/Projects"));
 const AddProjectPage = lazy(() => import("./pages/AddProject"));
 const UpdateProjectPage = lazy(() => import("./pages/UpdateProject"));
+const SeriesPage = lazy(() => import("./pages/Series"));
 
 function App() {
   return (
@@ -51,6 +52,7 @@ function App() {
             <Route path="/projects" element={<ProjectPage />} />
             <Route path="/add-project" element={<AddProjectPage />} />
             <Route path="/update-project/:id" element={<UpdateProjectPage />} />
+            <Route path="/series" element={<SeriesPage />} />
           </Route>
         </Routes>
 

--- a/frontend/src/components/common/TagInput.tsx
+++ b/frontend/src/components/common/TagInput.tsx
@@ -1,0 +1,93 @@
+import { useState, type KeyboardEvent } from "react";
+
+import { useGetTags } from "@/services/tags/tags-list";
+
+interface ITagInputProps {
+  value: string[];
+  onChange: (tags: string[]) => void;
+  placeholder?: string;
+}
+
+/**
+ * Controlled tag editor: renders the chosen tags as removable chips plus a text
+ * input. Enter or comma commits a tag; Backspace on an empty input removes the
+ * last one. Existing tags are offered as `<datalist>` suggestions.
+ */
+const TagInput: React.FC<ITagInputProps> = ({
+  value,
+  onChange,
+  placeholder,
+}) => {
+  const [draft, setDraft] = useState("");
+  const { tags: existingTags } = useGetTags();
+
+  const addTag = (raw: string) => {
+    const tag = raw.trim();
+    if (!tag) return;
+    const alreadyAdded = value.some(
+      (item) => item.toLowerCase() === tag.toLowerCase()
+    );
+    if (!alreadyAdded) onChange([...value, tag]);
+    setDraft("");
+  };
+
+  const removeTag = (index: number) =>
+    onChange(value.filter((_, i) => i !== index));
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter" || event.key === ",") {
+      event.preventDefault();
+      addTag(draft);
+    } else if (event.key === "Backspace" && !draft && value.length) {
+      removeTag(value.length - 1);
+    }
+  };
+
+  const suggestions = (existingTags ?? [])
+    .map((tag) => tag.name)
+    .filter(
+      (name) => !value.some((item) => item.toLowerCase() === name.toLowerCase())
+    );
+
+  return (
+    <div className="border-divider bg-bg-main w-full rounded-lg border px-3 py-2">
+      <div className="flex flex-wrap items-center gap-2">
+        {value.map((tag, index) => (
+          <span
+            key={`${tag}-${index}`}
+            className="bg-success-darker inline-flex items-center gap-x-1 rounded-full px-3 py-1 text-xs text-white"
+          >
+            {tag}
+            <button
+              type="button"
+              onClick={() => removeTag(index)}
+              aria-label={`Remove ${tag}`}
+              className="cursor-pointer text-sm leading-none"
+            >
+              ×
+            </button>
+          </span>
+        ))}
+
+        <input
+          list="tag-suggestions"
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={() => addTag(draft)}
+          placeholder={
+            value.length ? "" : placeholder ?? "Add a tag and press Enter"
+          }
+          className="text-d-body2 min-w-[8rem] flex-1 bg-transparent outline-none"
+        />
+        <datalist id="tag-suggestions">
+          {suggestions.map((name) => (
+            <option key={name} value={name} />
+          ))}
+        </datalist>
+      </div>
+    </div>
+  );
+};
+
+export default TagInput;

--- a/frontend/src/components/forms/BlogForm.tsx
+++ b/frontend/src/components/forms/BlogForm.tsx
@@ -18,6 +18,8 @@ import { HelperText } from "../common/HelperText";
 import ToggleButtonController from "../common/Toggle/toggle-button-controller";
 import CoverUploaderController from "../common/Uploader/CoverUploaderController";
 import { useDeleteBlog } from "@/services/blog/delete-blog";
+import { useGetSeries } from "@/services/series/series-list";
+import TagInput from "../common/TagInput";
 
 interface IBlogFormComponentProps {
   defaultValues?: IBlogFormDefaultValues;
@@ -31,6 +33,7 @@ const BlogForm: React.FC<IBlogFormComponentProps> = ({ defaultValues }) => {
     handleSubmit,
     reset,
     setError,
+    watch,
   } = useForm<IBlogFormProps>({
     defaultValues: {
       title: "",
@@ -39,8 +42,14 @@ const BlogForm: React.FC<IBlogFormComponentProps> = ({ defaultValues }) => {
       content: "",
       cover_image: "",
       is_featured: false,
+      seriesId: "",
+      series_order: null,
+      tags: [],
     },
   });
+
+  const { series } = useGetSeries();
+  const selectedSeriesId = watch("seriesId");
 
   const createBlogMutation = useCreateBlog();
   const updateBlogMutation = useUpdateBlog();
@@ -262,6 +271,72 @@ const BlogForm: React.FC<IBlogFormComponentProps> = ({ defaultValues }) => {
               control={control}
               name="is_featured"
               label={""}
+            />
+          </div>
+
+          <div className="flex flex-col gap-x-4 gap-y-2 md:flex-row">
+            <div className="flex-1 space-y-1">
+              <span className="text-secondary-text text-d-body2">Series</span>
+              <Controller
+                name="seriesId"
+                control={control}
+                render={({ field }) => (
+                  <select
+                    value={field.value}
+                    onChange={(event) => field.onChange(event.target.value)}
+                    className="border-disabled w-full rounded-lg border bg-transparent px-3 py-2 outline-none"
+                  >
+                    <option value="">No series</option>
+                    {(series ?? []).map((item) => (
+                      <option key={item.id} value={String(item.id)}>
+                        {item.title}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              />
+            </div>
+
+            {selectedSeriesId && (
+              <div className="flex-1 space-y-1">
+                <span className="text-secondary-text text-d-body2">
+                  Part number
+                </span>
+                <Controller
+                  name="series_order"
+                  control={control}
+                  render={({ field }) => (
+                    <input
+                      type="number"
+                      min={1}
+                      value={field.value ?? ""}
+                      onChange={(event) =>
+                        field.onChange(
+                          event.target.value === ""
+                            ? null
+                            : Number(event.target.value)
+                        )
+                      }
+                      placeholder="e.g. 1"
+                      className="border-disabled w-full rounded-lg border px-3 py-2 outline-none"
+                    />
+                  )}
+                />
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-1">
+            <span className="text-secondary-text text-d-body2">Tags</span>
+            <Controller
+              name="tags"
+              control={control}
+              render={({ field }) => (
+                <TagInput
+                  value={field.value ?? []}
+                  onChange={field.onChange}
+                />
+              )}
             />
           </div>
 

--- a/frontend/src/components/forms/ProjectForm.tsx
+++ b/frontend/src/components/forms/ProjectForm.tsx
@@ -18,6 +18,7 @@ import { queryClient } from "@/providers/QueryClientProvider";
 import { usePublishProject } from "@/services/projects/publish-project";
 import CoverUploaderController from "../common/Uploader/CoverUploaderController";
 import { useDeleteProject } from "@/services/projects/delete-project";
+import TagInput from "../common/TagInput";
 
 interface IProjectFormComponentProps {
   defaultValues?: IProjectFormDefaultValues;
@@ -41,6 +42,7 @@ const ProjectForm: React.FC<IProjectFormComponentProps> = ({
       content: "",
       cover_image: "",
       is_featured: false,
+      tags: [],
     },
   });
 
@@ -276,6 +278,20 @@ const ProjectForm: React.FC<IProjectFormComponentProps> = ({
               control={control}
               name="is_featured"
               label={""}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <span className="text-secondary-text text-d-body2">Tags</span>
+            <Controller
+              name="tags"
+              control={control}
+              render={({ field }) => (
+                <TagInput
+                  value={field.value ?? []}
+                  onChange={field.onChange}
+                />
+              )}
             />
           </div>
 

--- a/frontend/src/components/sections/SeriesSection.tsx
+++ b/frontend/src/components/sections/SeriesSection.tsx
@@ -1,0 +1,205 @@
+import { useState } from "react";
+import toast from "react-hot-toast";
+import { ClipLoader } from "react-spinners";
+
+import { Button } from "../common/Button";
+import { queryClient } from "@/providers/QueryClientProvider";
+import { useGetSeries } from "@/services/series/series-list";
+import { useCreateSeries } from "@/services/series/create-series";
+import { useUpdateSeries } from "@/services/series/update-series";
+import { useDeleteSeries } from "@/services/series/delete-series";
+import type { ISeriesListItem } from "@/types/series.types";
+
+const SeriesSection = () => {
+  const { series, isGettingSeries } = useGetSeries();
+  const createSeries = useCreateSeries();
+  const updateSeries = useUpdateSeries();
+  const deleteSeries = useDeleteSeries();
+
+  // null = creating a new series; a number = editing that series id
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+
+  const refresh = () =>
+    queryClient.invalidateQueries({ queryKey: ["series"] });
+
+  const resetForm = () => {
+    setEditingId(null);
+    setTitle("");
+    setDescription("");
+  };
+
+  const startEdit = (item: ISeriesListItem) => {
+    setEditingId(item.id);
+    setTitle(item.title);
+    setDescription(item.description ?? "");
+  };
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!title.trim()) {
+      toast.error("Series title is required.");
+      return;
+    }
+
+    const data = { title: title.trim(), description: description.trim() };
+    const onError = (error: Error) => {
+      const apiError = error.cause as TApiErrorResponse | undefined;
+      toast.error(apiError?.message || error.message || "Something went wrong.");
+    };
+
+    if (editingId !== null) {
+      updateSeries.mutate(
+        { id: editingId, data },
+        {
+          onSuccess: (response) => {
+            toast.success(response?.data?.message);
+            resetForm();
+            refresh();
+          },
+          onError,
+        }
+      );
+    } else {
+      createSeries.mutate(
+        { data },
+        {
+          onSuccess: (response) => {
+            toast.success(response?.data?.message);
+            resetForm();
+            refresh();
+          },
+          onError,
+        }
+      );
+    }
+  };
+
+  const handleDelete = (item: ISeriesListItem) => {
+    deleteSeries.mutate(
+      { id: item.id },
+      {
+        onSuccess: (response) => {
+          toast.success(response?.data?.message);
+          if (editingId === item.id) resetForm();
+          refresh();
+        },
+        onError: (error) => toast.error(error?.message),
+      }
+    );
+  };
+
+  const isSaving = createSeries.isPending || updateSeries.isPending;
+
+  return (
+    <main className="mx-auto w-full max-w-[900px] space-y-8 p-4">
+      <div>
+        <h4 className="font-semibold">Blog Series</h4>
+        <p className="text-secondary-text text-d-body2">
+          Group related posts into an ordered series. Assign a blog to a series
+          and set its part number from the blog editor.
+        </p>
+      </div>
+
+      <form
+        onSubmit={handleSubmit}
+        className="border-divider bg-bg-main space-y-3 rounded-lg border p-4"
+      >
+        <h6 className="font-medium">
+          {editingId !== null ? "Edit series" : "Create a new series"}
+        </h6>
+
+        <input
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+          placeholder="Series title"
+          className="border-disabled w-full rounded-lg border px-3 py-2 outline-none"
+        />
+
+        <textarea
+          value={description}
+          onChange={(event) => setDescription(event.target.value)}
+          placeholder="Short description (optional)"
+          rows={3}
+          className="border-disabled w-full rounded-lg border px-3 py-2 outline-none"
+        />
+
+        <div className="flex items-center gap-2">
+          <Button type="submit" size="sm" colorType="success">
+            {isSaving ? (
+              <ClipLoader size={10} />
+            ) : editingId !== null ? (
+              "Update series"
+            ) : (
+              "Create series"
+            )}
+          </Button>
+
+          {editingId !== null && (
+            <Button
+              type="button"
+              size="sm"
+              variant="outlined"
+              onClick={resetForm}
+            >
+              Cancel
+            </Button>
+          )}
+        </div>
+      </form>
+
+      {isGettingSeries ? (
+        <div className="flex justify-center py-6">
+          <ClipLoader size={20} />
+        </div>
+      ) : !series || series.length === 0 ? (
+        <p className="text-secondary-text py-6 text-center">
+          No series yet. Create one above.
+        </p>
+      ) : (
+        <ul className="space-y-3">
+          {series.map((item) => (
+            <li
+              key={item.id}
+              className="border-divider flex items-start justify-between gap-4 rounded-lg border p-4"
+            >
+              <div className="space-y-1">
+                <p className="font-medium">{item.title}</p>
+                {item.description && (
+                  <p className="text-secondary-text text-d-body2">
+                    {item.description}
+                  </p>
+                )}
+                <p className="text-secondary-text text-xs">
+                  {item.blogs_count} blog{item.blogs_count === 1 ? "" : "s"}
+                </p>
+              </div>
+
+              <div className="flex shrink-0 items-center gap-2">
+                <Button
+                  size="sm"
+                  variant="outlined"
+                  colorType="success"
+                  onClick={() => startEdit(item)}
+                >
+                  Edit
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outlined"
+                  colorType="error"
+                  onClick={() => handleDelete(item)}
+                >
+                  {deleteSeries.isPending ? <ClipLoader size={10} /> : "Delete"}
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+};
+
+export default SeriesSection;

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -22,11 +22,16 @@ export const SIDEBAR_LINKS: ISidebarLinkProp[] = [
   },
   {
     id: 4,
+    title: "Series",
+    href: "/series",
+  },
+  {
+    id: 5,
     title: "Projects",
     href: "/projects",
   },
   {
-    id: 5,
+    id: 6,
     title: "Add Project",
     href: "/add-project",
   },

--- a/frontend/src/pages/Series.tsx
+++ b/frontend/src/pages/Series.tsx
@@ -1,0 +1,7 @@
+import SeriesSection from "@/components/sections/SeriesSection";
+
+const SeriesPage = () => {
+  return <SeriesSection />;
+};
+
+export default SeriesPage;

--- a/frontend/src/pages/UpdateBlog.tsx
+++ b/frontend/src/pages/UpdateBlog.tsx
@@ -37,6 +37,9 @@ const UpdateBlog = () => {
             title: blogData?.title,
             is_draft: blogData?.is_draft,
             is_featured: blogData?.is_featured,
+            seriesId: blogData?.seriesId ? String(blogData.seriesId) : "",
+            series_order: blogData?.series_order ?? null,
+            tags: blogData?.tags ?? [],
           }}
         />
       </main>

--- a/frontend/src/pages/UpdateProject.tsx
+++ b/frontend/src/pages/UpdateProject.tsx
@@ -37,6 +37,7 @@ const UpdateProject = () => {
             title: projectData?.title,
             is_draft: projectData?.is_draft,
             is_featured: projectData?.is_featured,
+            tags: projectData?.tags ?? [],
           }}
         />
       </main>

--- a/frontend/src/services/series/create-series.ts
+++ b/frontend/src/services/series/create-series.ts
@@ -1,0 +1,19 @@
+import { createData } from "@/core/http-service";
+import type {
+  ISeriesFormProps,
+  TMutateSeriesResponse,
+} from "@/types/series.types";
+import { useMutation } from "@tanstack/react-query";
+
+const createSeries = async (data: ISeriesFormProps) => {
+  return await createData<TMutateSeriesResponse>("/series", data);
+};
+
+export const useCreateSeries = () => {
+  const mutation = useMutation({
+    mutationKey: ["create-series"],
+    mutationFn: ({ data }: { data: ISeriesFormProps }) => createSeries(data),
+  });
+
+  return { ...mutation, isCreatingSeries: mutation?.isPending };
+};

--- a/frontend/src/services/series/delete-series.ts
+++ b/frontend/src/services/series/delete-series.ts
@@ -1,0 +1,15 @@
+import { deleteData } from "@/core/http-service";
+import { useMutation } from "@tanstack/react-query";
+
+const deleteSeries = async (id: number) => {
+  return await deleteData<TResponse<object>>(`/series/${id}`);
+};
+
+export const useDeleteSeries = () => {
+  const mutation = useMutation({
+    mutationKey: ["delete-series"],
+    mutationFn: ({ id }: { id: number }) => deleteSeries(id),
+  });
+
+  return { ...mutation, isDeletingSeries: mutation?.isPending };
+};

--- a/frontend/src/services/series/series-list.ts
+++ b/frontend/src/services/series/series-list.ts
@@ -1,0 +1,19 @@
+import { readData } from "@/core/http-service";
+import type { TSeriesListResponse } from "@/types/series.types";
+import { useQuery } from "@tanstack/react-query";
+
+const getSeriesList = async () => {
+  return await readData<TSeriesListResponse>("/series");
+};
+
+export const useGetSeries = () => {
+  const { data, isPending } = useQuery({
+    queryKey: ["series"],
+    queryFn: getSeriesList,
+  });
+
+  return {
+    isGettingSeries: isPending,
+    series: data?.data?.data,
+  };
+};

--- a/frontend/src/services/series/update-series.ts
+++ b/frontend/src/services/series/update-series.ts
@@ -1,0 +1,20 @@
+import { updateData } from "@/core/http-service";
+import type {
+  ISeriesFormProps,
+  TMutateSeriesResponse,
+} from "@/types/series.types";
+import { useMutation } from "@tanstack/react-query";
+
+const updateSeries = async (id: number, data: ISeriesFormProps) => {
+  return await updateData<TMutateSeriesResponse>(`/series/${id}`, data);
+};
+
+export const useUpdateSeries = () => {
+  const mutation = useMutation({
+    mutationKey: ["update-series"],
+    mutationFn: ({ id, data }: { id: number; data: ISeriesFormProps }) =>
+      updateSeries(id, data),
+  });
+
+  return { ...mutation, isUpdatingSeries: mutation?.isPending };
+};

--- a/frontend/src/services/tags/tags-list.ts
+++ b/frontend/src/services/tags/tags-list.ts
@@ -1,0 +1,20 @@
+import { readData } from "@/core/http-service";
+import type { TTagListResponse } from "@/types/tags.types";
+import { useQuery } from "@tanstack/react-query";
+
+const getTagsList = async () => {
+  return await readData<TTagListResponse>("/tag");
+};
+
+/** All of the current user's tags — used to power form autocomplete. */
+export const useGetTags = () => {
+  const { data, isPending } = useQuery({
+    queryKey: ["tags"],
+    queryFn: getTagsList,
+  });
+
+  return {
+    isGettingTags: isPending,
+    tags: data?.data?.data,
+  };
+};

--- a/frontend/src/types/blogs.types.ts
+++ b/frontend/src/types/blogs.types.ts
@@ -1,3 +1,5 @@
+import type { ISeriesSummary } from "./series.types";
+
 export interface IBlogsCardProps {
   id: number;
   title: string;
@@ -13,10 +15,14 @@ export interface IBlogsCardProps {
   is_draft: true;
   reading_time: number;
   is_featured: boolean;
+  series?: ISeriesSummary | null;
+  series_order?: number | null;
+  tags?: string[];
 }
 
 export interface ISingleBlogData extends IBlogsCardProps {
   content: string;
+  seriesId?: number | null;
 }
 
 export interface IBlogFormProps {
@@ -26,6 +32,10 @@ export interface IBlogFormProps {
   content: string;
   cover_image: string;
   is_featured: boolean;
+  // "" = no series; otherwise the numeric series id as a string (native <select>)
+  seriesId: string;
+  series_order: number | null;
+  tags: string[];
 }
 
 export interface IBlogFormDefaultValues extends IBlogFormProps {

--- a/frontend/src/types/projects.types.ts
+++ b/frontend/src/types/projects.types.ts
@@ -10,6 +10,7 @@ export interface IProjectCardProps {
   updated_at: string;
   is_draft: boolean;
   is_featured: boolean;
+  tags?: string[];
 }
 
 export interface IProjectFormProps {
@@ -19,6 +20,7 @@ export interface IProjectFormProps {
   content: string;
   cover_image: string;
   is_featured: boolean;
+  tags: string[];
 }
 
 export interface IProjectFormDefaultValues extends IProjectFormProps {

--- a/frontend/src/types/series.types.ts
+++ b/frontend/src/types/series.types.ts
@@ -1,0 +1,36 @@
+export interface ISeriesSummary {
+  id: number;
+  title: string;
+  slug: string;
+}
+
+export interface ISeriesListItem extends ISeriesSummary {
+  description: string | null;
+  created_at: string;
+  updated_at: string;
+  blogs_count: number;
+}
+
+export interface ISeriesBlogItem {
+  id: number;
+  title: string;
+  slug: string;
+  series_order: number | null;
+  is_draft: boolean;
+}
+
+export interface ISeriesDetail extends ISeriesSummary {
+  description: string | null;
+  created_at: string;
+  updated_at: string;
+  blogs: ISeriesBlogItem[];
+}
+
+export interface ISeriesFormProps {
+  title: string;
+  description: string;
+}
+
+export type TSeriesListResponse = TResponseArr<ISeriesListItem>;
+export type TSeriesDetailResponse = TResponse<ISeriesDetail>;
+export type TMutateSeriesResponse = TResponse<ISeriesSummary>;

--- a/frontend/src/types/tags.types.ts
+++ b/frontend/src/types/tags.types.ts
@@ -1,0 +1,9 @@
+export interface ITagListItem {
+  id: number;
+  name: string;
+  slug: string;
+  blogs_count: number;
+  projects_count: number;
+}
+
+export type TTagListResponse = TResponseArr<ITagListItem>;


### PR DESCRIPTION
Series (P3) — one series per blog:
- Series model (per-user unique slug) + Blog.seriesId/series_order; m2m Tag join tables. Migration generated offline via `prisma migrate diff`.
- Series CRUD endpoints (/series) scoped to the owner.
- Public single-blog payload gains a "Part N of M" context: ordered published siblings, current part, total, and prev/next navigation (buildSeriesContext). New public /public/:username/series/:slug landing.
- Panel UI: Series management page (create/edit/delete) + a series selector and part-number field in the blog editor.

Tags (P4) — shared across blogs and projects:
- Tag model (per-user unique slug), implicit m2m to Blog and Project.
- resolveTagConnections upserts tags by name on blog/project create & update (set-semantics on update; empty list clears).
- Tag CRUD endpoints (/tag) + public /public/:username/tags with published-only counts; optional ?tag=slug filter on the public blog and project lists.
- Panel UI: a chip-style TagInput with autocomplete from existing tags, wired into both the blog and project editors.

Public list endpoints now order by published_at desc.

Apply the migration after pulling:
  cd backend && npx prisma migrate deploy   # or `migrate dev` in development

Verified: backend `tsc --noEmit` clean; frontend `tsc -b && vite build` green.