### PR TITLE
feat(p7): production Dockerfiles + Docker Swarm stack + deploy guide

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,133 @@
+# Deploying Notiq (Docker Swarm)
+
+Production deployment uses two images — `notiq-backend` (Express API + Postgres
+migrations) and `notiq-frontend` (the panel built to static files, served by
+nginx) — orchestrated by [`docker-stack.yml`](docker-stack.yml) with a Postgres
+service, named volumes, and Swarm secrets.
+
+```
+            ┌────────────┐         ┌────────────┐        ┌──────────┐
+  :80  ───▶ │  frontend  │   :8080 │  backend   │ ─────▶ │ postgres │
+  (nginx SPA)│  (×2)      │  ◀──────│  (×2)      │        │  (×1)    │
+            └────────────┘  API    └────────────┘        └──────────┘
+                                     uploads_data vol      db_data vol
+```
+
+> **TLS:** the stack publishes plain HTTP (`:80`, `:8080`). In production put it
+> behind a TLS-terminating reverse proxy (Traefik, Caddy, nginx, or a cloud LB).
+
+---
+
+## 1. Prerequisites
+
+- Docker Engine with Swarm mode: `docker swarm init`
+- A container registry you can push to (Docker Hub, GHCR, a private registry).
+  For a single-node Swarm you can skip the registry and build locally.
+
+---
+
+## 2. Build & push the images
+
+The frontend bakes its API URL at **build time**, so set `VITE_API_BASE_URL` to
+the backend's public URL when you build it.
+
+```bash
+export REGISTRY=ghcr.io/yourname    # or your Docker Hub user
+export TAG=1.0.0
+
+# Backend
+docker build -t $REGISTRY/notiq-backend:$TAG ./backend
+docker push $REGISTRY/notiq-backend:$TAG
+
+# Frontend — point it at the public backend URL
+docker build \
+  --build-arg VITE_API_BASE_URL=https://api.example.com \
+  -t $REGISTRY/notiq-frontend:$TAG ./frontend
+docker push $REGISTRY/notiq-frontend:$TAG
+```
+
+---
+
+## 3. Create the secrets
+
+The stack reads three Swarm secrets. `db_url` is the full Prisma connection
+string and **must** embed the same password as `db_password`.
+
+```bash
+printf 'a-long-random-string'                              | docker secret create jwt_secret -
+printf 'super-secret-db-password'                          | docker secret create db_password -
+printf 'postgresql://blog_user:super-secret-db-password@db:5432/blog_panel' \
+                                                           | docker secret create db_url -
+```
+
+> Use `printf` (not `echo`) so no trailing newline sneaks into the secret.
+
+---
+
+## 4. Configure & deploy
+
+`docker stack deploy` substitutes variables from your shell environment:
+
+```bash
+export REGISTRY=ghcr.io/yourname
+export TAG=1.0.0
+export CORS_ORIGINS=https://panel.example.com,https://www.example.com
+export POSTGRES_USER=blog_user
+export POSTGRES_DB=blog_panel
+
+docker stack deploy -c docker-stack.yml notiq
+```
+
+On boot the backend entrypoint loads the secrets, runs `prisma migrate deploy`,
+then starts the API. With multiple replicas, Prisma's migration advisory lock
+serializes them — only one applies the migrations. If the DB isn't ready yet the
+container exits and Swarm restarts it until it succeeds.
+
+---
+
+## 5. Verify
+
+```bash
+docker stack services notiq          # all replicas should reach n/n
+docker service logs notiq_backend -f # watch migrations + startup
+curl -fsS http://<host>:8080/health  # {"status":"ok",...}
+```
+
+---
+
+## 6. Update (rolling, zero-downtime)
+
+Build & push a new `TAG`, then redeploy — `update_config: order: start-first`
+brings up the new task before stopping the old one:
+
+```bash
+export TAG=1.0.1
+# rebuild + push both images...
+docker stack deploy -c docker-stack.yml notiq
+```
+
+---
+
+## 7. Backups
+
+```bash
+# Database
+docker exec $(docker ps -qf name=notiq_db) \
+  pg_dump -U blog_user blog_panel > backup-$(date +%F).sql
+
+# Uploaded media (named volume)
+docker run --rm -v notiq_uploads_data:/data -v "$PWD":/backup busybox \
+  tar czf /backup/uploads-$(date +%F).tar.gz -C /data .
+```
+
+---
+
+## Local development
+
+For a single-host dev run use the compose file instead of the Swarm stack:
+
+```bash
+cp backend/.env.example backend/.env     # fill in DATABASE_URL + JWT_SECRET_KEY
+docker compose up --build
+# panel → http://localhost:5173 , API → http://localhost:4000
+```

--- a/README.md
+++ b/README.md
@@ -118,5 +118,10 @@ A single published blog includes a `series` object when it belongs to one:
 
 ## Deployment
 
-Production Docker images and a Docker Swarm stack are provided — see the deploy
-guide (added in the deployment phase).
+Production multi-stage Dockerfiles (`backend/Dockerfile`, `frontend/Dockerfile`)
+and a Docker Swarm stack (`docker-stack.yml`) are provided — non-root backend,
+healthchecks, graceful shutdown, secrets, persistent volumes, and an
+nginx-served SPA. See **[DEPLOY.md](DEPLOY.md)** for the full guide.
+
+For local development, `docker compose up --build` runs the whole stack
+(panel on `:5173`, API on `:4000`).

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+dist
+.env
+.env.*
+!.env.example
+.git
+.gitignore
+npm-debug.log*
+*.log
+Dockerfile
+.dockerignore
+src/uploads

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,23 +1,41 @@
-FROM node:22-bullseye-slim AS builder
+# ---- Build stage ----
+FROM node:22-bookworm-slim AS builder
 
-WORKDIR /app 
-
-COPY package*json ./
-RUN npm install
-
-COPY . .
-RUN npm run build
-RUN npx prisma generate
-
-# ---- Runtime Stage ----
-  
-FROM node:22-bullseye-slim
-  
 WORKDIR /app
 
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npx prisma generate && npm run build
+
+# ---- Runtime stage ----
+FROM node:22-bookworm-slim AS runner
+
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=8080
+
+# Carry over installed deps (incl. the generated Prisma client and the Prisma
+# CLI used by `migrate deploy`), the compiled app, the schema/migrations, the
+# manifest, and the entrypoint.
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/prisma ./prisma
+COPY --from=builder /app/package.json ./package.json
+COPY docker-entrypoint.sh ./docker-entrypoint.sh
 
-EXPOSE 4000
-CMD sh -c "npx prisma migrate deploy && node dist/app.js"
+# Uploads are written to dist/src/uploads — make it writable (persist via a
+# volume in production) and drop to the unprivileged node user.
+RUN chmod +x ./docker-entrypoint.sh \
+  && mkdir -p /app/dist/src/uploads \
+  && chown -R node:node /app
+
+USER node
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||8080)+'/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/backend/app.ts
+++ b/backend/app.ts
@@ -4,6 +4,7 @@ import helmet from "helmet";
 import morgan from "morgan";
 import dotenv from "dotenv";
 import path from "path";
+import fs from "fs";
 import rateLimit from "express-rate-limit";
 
 import { router as authRouter } from "./src/routes/auth.js";
@@ -22,6 +23,20 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 dotenv.config();
+
+// Support Docker/Swarm secrets: when VAR_FILE points to a file, load VAR from
+// it (unless VAR is already set directly). Mirrors what the entrypoint does for
+// the Prisma CLI, so running `node dist/app.js` standalone also works.
+for (const key of ["JWT_SECRET_KEY", "DATABASE_URL"]) {
+  const filePath = process.env[`${key}_FILE`];
+  if (filePath && !process.env[key]) {
+    try {
+      process.env[key] = fs.readFileSync(filePath, "utf8").trim();
+    } catch {
+      console.error(`Failed to read ${key}_FILE at ${filePath}`);
+    }
+  }
+}
 
 const isProduction = process.env.NODE_ENV === "production";
 

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+# Resolve Docker/Swarm secrets: when VAR_FILE points to a file, export VAR from
+# it. Done in the shell so `prisma migrate deploy` (below) sees DATABASE_URL too.
+for var in JWT_SECRET_KEY DATABASE_URL; do
+  file=$(eval "printf '%s' \"\${${var}_FILE:-}\"")
+  if [ -n "$file" ] && [ -f "$file" ]; then
+    export "$var=$(cat "$file")"
+  fi
+done
+
+echo "→ Applying database migrations (prisma migrate deploy)..."
+npx prisma migrate deploy
+
+echo "→ Starting Notiq API..."
+exec node dist/app.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,8 @@
 name: blog-panel
 
+# Local development / single-host stack. For production Swarm, use
+# docker-stack.yml (see DEPLOY.md).
+
 services:
   db:
     image: postgres:16
@@ -17,13 +20,14 @@ services:
       context: ./backend
     env_file:
       - ./backend/.env
+    # host 4000 -> container 8080 (the app's default port). The image
+    # entrypoint runs `prisma migrate deploy` then starts the server.
     ports:
-      - "4000:4000"
+      - "4000:8080"
     depends_on:
       - db
-    command: sh -c "npx prisma migrate deploy && node dist/app.js"
     volumes:
-      - uploads_data:/app/uploads # persist uploads
+      - uploads_data:/app/dist/src/uploads # persist uploads
 
   frontend:
     build:
@@ -38,4 +42,4 @@ services:
 
 volumes:
   db_data:
-  uploads_data: # named volume form uploads
+  uploads_data: # named volume for uploads

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -1,0 +1,102 @@
+# Production Docker Swarm stack for Notiq.
+#
+#   docker stack deploy -c docker-stack.yml notiq
+#
+# Prerequisites (see DEPLOY.md):
+#   - Built + pushed images (REGISTRY/notiq-backend, REGISTRY/notiq-frontend)
+#   - Swarm secrets: jwt_secret, db_password, db_url
+#   - Optional env overrides: REGISTRY, TAG, CORS_ORIGINS, POSTGRES_USER, POSTGRES_DB
+
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-blog_user}
+      POSTGRES_DB: ${POSTGRES_DB:-blog_panel}
+      POSTGRES_PASSWORD_FILE: /run/secrets/db_password
+    secrets:
+      - db_password
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    networks:
+      - blog_net
+    healthcheck:
+      test:
+        ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-blog_user} -d ${POSTGRES_DB:-blog_panel}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    deploy:
+      replicas: 1
+      placement:
+        # The named volume lives on one node; pin Postgres to it. For HA, use a
+        # replicated volume driver and a fixed node constraint instead.
+        constraints: [node.role == manager]
+      restart_policy:
+        condition: on-failure
+
+  backend:
+    image: ${REGISTRY:-localhost}/notiq-backend:${TAG:-latest}
+    environment:
+      NODE_ENV: production
+      PORT: "8080"
+      DATABASE_URL_FILE: /run/secrets/db_url
+      JWT_SECRET_KEY_FILE: /run/secrets/jwt_secret
+      CORS_ORIGINS: ${CORS_ORIGINS:-}
+    secrets:
+      - db_url
+      - jwt_secret
+    volumes:
+      - uploads_data:/app/dist/src/uploads
+    networks:
+      - blog_net
+    ports:
+      - "8080:8080"
+    init: true
+    # Healthcheck + graceful shutdown come from the image (Dockerfile + app.ts).
+    deploy:
+      replicas: 2
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+      update_config:
+        order: start-first
+        parallelism: 1
+      resources:
+        limits:
+          cpus: "0.75"
+          memory: 512M
+
+  frontend:
+    image: ${REGISTRY:-localhost}/notiq-frontend:${TAG:-latest}
+    networks:
+      - blog_net
+    ports:
+      - "80:80"
+    deploy:
+      replicas: 2
+      restart_policy:
+        condition: on-failure
+      update_config:
+        order: start-first
+        parallelism: 1
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: 128M
+
+networks:
+  blog_net:
+    driver: overlay
+
+volumes:
+  db_data:
+  uploads_data:
+
+secrets:
+  jwt_secret:
+    external: true
+  db_password:
+    external: true
+  db_url:
+    external: true

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+dist
+.env
+.env.*
+!.env.example
+.git
+.gitignore
+npm-debug.log*
+*.log
+Dockerfile
+Dockerfile.dev
+.dockerignore

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,21 +1,28 @@
-FROM node:22-bullseye-slim AS builder
+# ---- Build stage ----
+FROM node:22-bookworm-slim AS builder
 
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm install
+RUN npm ci
+
+# Vite inlines env vars at build time, so the API URL must be known here. Pass
+# it with `--build-arg VITE_API_BASE_URL=https://api.example.com`.
+ARG VITE_API_BASE_URL=http://localhost:8080
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 
 COPY . .
 RUN npm run build
 
-# ---- production ----
-FROM nginx:alpine
+# ---- Runtime stage ----
+FROM nginx:alpine AS runner
 
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/dist /usr/share/nginx/html
 
-
-# Copy custom nginx config if needed
-# COPY nginx.conf /etc/nginx/conf.d/default.conf
-
 EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://127.0.0.1/ >/dev/null 2>&1 || exit 1
+
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,35 @@
+server {
+  listen 80;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  gzip on;
+  gzip_comp_level 5;
+  gzip_min_length 1024;
+  gzip_types text/css application/javascript application/json image/svg+xml;
+
+  # Hashed build assets are immutable — cache them hard.
+  location /assets/ {
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+    try_files $uri =404;
+  }
+
+  # SPA fallback: every unknown path serves index.html so client routing works.
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
+  # Optional: proxy the API through nginx to avoid CORS. To use it, build the
+  # frontend with VITE_API_BASE_URL=/api and uncomment this block. Note the
+  # backend builds absolute upload URLs from the request host, so it must honor
+  # the X-Forwarded-* headers below.
+  # location /api/ {
+  #   proxy_pass http://backend:8080/;
+  #   proxy_set_header Host $host;
+  #   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  #   proxy_set_header X-Forwarded-Proto $scheme;
+  # }
+}


### PR DESCRIPTION
Backend image:
- Multi-stage build (npm ci → prisma generate → tsc), slim runtime that runs as the non-root `node` user, with a /health HEALTHCHECK and EXPOSE 8080.
- docker-entrypoint.sh resolves *_FILE Docker/Swarm secrets, runs `prisma migrate deploy`, then execs the server (so SIGTERM reaches Node for graceful shutdown). app.ts gained the same *_FILE resolution for standalone runs. Uploads dir (dist/src/uploads) created and owned by node.

Frontend image:
- Multi-stage build → nginx:alpine serving the SPA, with a build-arg for VITE_API_BASE_URL (Vite inlines it at build time), an nginx.conf with SPA fallback + asset caching + gzip (and a commented /api proxy), and a healthcheck.

Orchestration & docs:
- docker-stack.yml (Swarm): Postgres + db_data volume + db_password secret, backend (2 replicas, secrets, uploads_data volume, init, rolling updates, resource limits), frontend (2 replicas), overlay network, external secrets.
- .dockerignore for both apps; dev docker-compose.yml fixed (correct uploads mount path, host:container port, entrypoint now owns migrate+start).
- DEPLOY.md end-to-end guide (build/push, secrets, deploy, verify, rolling update, backups, TLS note) + README deployment section.

Verified: backend `tsc --noEmit` clean; both images build (`docker build`) and the backend image runs as non-root with the Prisma CLI + compiled app present.