### PR TITLE
feat(panel-ui): vibrant header CTAs, editor toolbars, and card badges

### DIFF
--- a/frontend/src/components/common/BlogCard.tsx
+++ b/frontend/src/components/common/BlogCard.tsx
@@ -14,6 +14,7 @@ const BlogCard: React.FC<IBlogsCardProps> = ({
   views_count,
   reading_time,
   is_featured,
+  tags,
 }) => {
   return (
     <article className="group hover:shadow-drop-down transition-all duration-300 hover:-translate-y-2 w-full bg-white rounded-lg shadow-card overflow-hidden p-6">
@@ -30,12 +31,18 @@ const BlogCard: React.FC<IBlogsCardProps> = ({
 
         <div className="flex items-center gap-2">
           {is_featured && (
-            <span className="bg-success-lighter text-success text-m-body2 flex items-center justify-center text-center w-max py-2 px-4 uppercase">
+            <span className="bg-success-lighter text-success text-d-caption flex w-max items-center justify-center rounded-full px-3 py-1 font-semibold uppercase">
               featured
             </span>
           )}
-          <span className="bg-error-lighter text-error text-m-body2 flex items-center justify-center text-center w-max py-2 px-4 uppercase">
-            {is_draft ? "not published" : "published"}
+          <span
+            className={`text-d-caption flex w-max items-center justify-center rounded-full px-3 py-1 font-semibold uppercase ${
+              is_draft
+                ? "bg-warning-lighter text-warning"
+                : "bg-success-lighter text-success"
+            }`}
+          >
+            {is_draft ? "draft" : "published"}
           </span>
         </div>
 
@@ -48,6 +55,19 @@ const BlogCard: React.FC<IBlogsCardProps> = ({
             <p className="text-m-body2 text-secondary-text">
               {short_description}
             </p>
+
+            {tags && tags.length > 0 && (
+              <div className="flex flex-wrap items-center gap-1.5 pt-1">
+                {tags.slice(0, 3).map((tag) => (
+                  <span
+                    key={tag}
+                    className="bg-success/10 text-success text-d-caption rounded-full px-2 py-0.5"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
           </div>
 
           <div className="flex items-center justify-between">

--- a/frontend/src/components/common/HeaderNavigation.tsx
+++ b/frontend/src/components/common/HeaderNavigation.tsx
@@ -1,4 +1,4 @@
-// import { ArrowDown } from "lucide-react";
+import { Plus } from "lucide-react";
 import { NavLink, useNavigate } from "react-router";
 import { Button } from "./Button";
 import { useGetProfile } from "@/services/user-profile";
@@ -44,21 +44,28 @@ const HeaderNavigation = () => {
         </div>
 
         <div className="flex items-center gap-x-4">
-        <ul className="items-center gap-x-3 hidden lg:flex">
-          {SIDEBAR_LINKS?.slice(1)?.map((item) => (
-            <NavLink
-              key={item?.id}
-              to={item?.href}
-              className={({ isActive }) =>
-                customTwMerge(
-                  "hover:text-success font-medium text-d-subtitle2 transition-all duration-500 ease-in-out",
-                  isActive && "text-success hover:text-success font-semibold"
-                )
-              }
-            >
-              {item?.title}
-            </NavLink>
-          ))}
+        <ul className="hidden items-center gap-x-2 lg:flex">
+          {SIDEBAR_LINKS?.slice(1)?.map((item) => {
+            const isCreate = item?.href?.startsWith("/add-");
+            return (
+              <li key={item?.id}>
+                <NavLink
+                  to={item?.href}
+                  className={({ isActive }) =>
+                    isCreate
+                      ? "bg-success hover:bg-success-dark hover:shadow-success text-d-subtitle2 flex items-center gap-1.5 rounded-full px-4 py-2 font-semibold text-white transition-all duration-300"
+                      : customTwMerge(
+                          "text-secondary-text hover:bg-success/8 hover:text-success text-d-subtitle2 rounded-full px-3 py-2 font-medium transition-all duration-300",
+                          isActive && "bg-success/10 text-success font-semibold"
+                        )
+                  }
+                >
+                  {isCreate && <Plus size={16} />}
+                  {item?.title}
+                </NavLink>
+              </li>
+            );
+          })}
         </ul>
 
         <div className="hidden lg:block">

--- a/frontend/src/components/common/ProjectCard.tsx
+++ b/frontend/src/components/common/ProjectCard.tsx
@@ -9,6 +9,7 @@ const ProjectCard: React.FC<IProjectCardProps> = ({
   is_draft,
   id,
   is_featured,
+  tags,
 }) => {
   return (
     <article className="group hover:shadow-drop-down transition-all duration-300 hover:-translate-y-2 w-full bg-white rounded-lg shadow-card overflow-hidden p-6">
@@ -28,12 +29,18 @@ const ProjectCard: React.FC<IProjectCardProps> = ({
 
         <div className="flex items-center gap-2">
           {is_featured && (
-            <span className="bg-success-lighter text-success text-m-body2 flex items-center justify-center text-center w-max py-2 px-4 uppercase">
+            <span className="bg-success-lighter text-success text-d-caption flex w-max items-center justify-center rounded-full px-3 py-1 font-semibold uppercase">
               featured
             </span>
           )}
-          <span className="bg-error-lighter text-error text-m-body2 flex items-center justify-center text-center w-max py-2 px-4 uppercase">
-            {is_draft ? "not published" : "published"}
+          <span
+            className={`text-d-caption flex w-max items-center justify-center rounded-full px-3 py-1 font-semibold uppercase ${
+              is_draft
+                ? "bg-warning-lighter text-warning"
+                : "bg-success-lighter text-success"
+            }`}
+          >
+            {is_draft ? "draft" : "published"}
           </span>
         </div>
 
@@ -48,22 +55,19 @@ const ProjectCard: React.FC<IProjectCardProps> = ({
             </p>
           </div>
 
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              {/* //todo: for showing the count for comment on the blog for future */}
-              {/* <div className="flex items-center text-secondary-text text-d-caption gap-1">
-                <MessageCircle size={16} />
-                <span>4</span>
-              </div> */}
-
-              {/* <span className="text-secondary-text text-d-caption">|</span> */}
-
-              <div className="flex items-center text-secondary-text text-d-caption gap-1">
-                <span>2 min read</span>
-              </div>
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex flex-wrap items-center gap-1.5">
+              {tags?.slice(0, 3).map((tag) => (
+                <span
+                  key={tag}
+                  className="bg-success/10 text-success text-d-caption rounded-full px-2 py-0.5"
+                >
+                  {tag}
+                </span>
+              ))}
             </div>
 
-            <div className="flex items-center gap-2">
+            <div className="flex shrink-0 items-center gap-2">
               <span className="text-secondary-text text-d-caption">
                 {convertDateFormat(created_at)}
               </span>

--- a/frontend/src/components/forms/BlogForm.tsx
+++ b/frontend/src/components/forms/BlogForm.tsx
@@ -13,13 +13,13 @@ import TextFieldController from "../common/text-field/TextFieldController";
 import BlogTextEditor, { MAX_FILE_SIZE } from "../common/BlogTextEditor";
 import { useUpdateBlog } from "@/services/blog/update-blog";
 import { usePublishBlog } from "@/services/blog/publish-blog";
-import { ClipLoader } from "react-spinners";
 import { HelperText } from "../common/HelperText";
 import ToggleButtonController from "../common/Toggle/toggle-button-controller";
 import CoverUploaderController from "../common/Uploader/CoverUploaderController";
 import { useDeleteBlog } from "@/services/blog/delete-blog";
 import { useGetSeries } from "@/services/series/series-list";
 import TagInput from "../common/TagInput";
+import { EyeOff, Save, Send, Trash2 } from "lucide-react";
 
 interface IBlogFormComponentProps {
   defaultValues?: IBlogFormDefaultValues;
@@ -178,43 +178,56 @@ const BlogForm: React.FC<IBlogFormComponentProps> = ({ defaultValues }) => {
 
   return (
     <>
-      <header className="flex items-center mb-3 gap-2 justify-end">
-        {defaultValues && (
+      <header className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <h1 className="text-xl font-bold">
+          {defaultValues ? "Edit blog" : "Write a blog"}
+        </h1>
+
+        <div className="flex items-center gap-2">
+          {defaultValues && (
+            <Button
+              size="sm"
+              colorType="error"
+              variant="outlined"
+              disabled={!defaultValues?.is_draft}
+              isLoading={deleteBlogMutation?.isDeleting}
+              icon={<Trash2 size={16} />}
+              onClick={deleteBlogHandler}
+            >
+              Delete
+            </Button>
+          )}
+
           <Button
-            colorType="error"
+            size="sm"
+            type="submit"
+            form="add-blog"
             variant="outlined"
-            disabled={!defaultValues?.is_draft}
-            onClick={deleteBlogHandler}
+            colorType="success"
+            isLoading={isLoading}
+            icon={<Save size={16} />}
           >
-            {deleteBlogMutation?.isDeleting ? (
-              <ClipLoader size={10} />
-            ) : (
-              "Delete"
-            )}
+            Save
           </Button>
-        )}
 
-        <Button
-          size="sm"
-          type="submit"
-          form="add-blog"
-          variant="outlined"
-          colorType="success"
-        >
-          {isLoading ? <ClipLoader size={10} /> : "Save"}
-        </Button>
-
-        {defaultValues && (
-          <Button size="sm" colorType="success" onClick={handlePublishBlog}>
-            {isPublishing ? (
-              <ClipLoader size={10} />
-            ) : defaultValues?.is_draft ? (
-              "Publish"
-            ) : (
-              "Unpublish"
-            )}
-          </Button>
-        )}
+          {defaultValues && (
+            <Button
+              size="sm"
+              colorType="success"
+              isLoading={isPublishing}
+              icon={
+                defaultValues?.is_draft ? (
+                  <Send size={16} />
+                ) : (
+                  <EyeOff size={16} />
+                )
+              }
+              onClick={handlePublishBlog}
+            >
+              {defaultValues?.is_draft ? "Publish" : "Unpublish"}
+            </Button>
+          )}
+        </div>
       </header>
 
       <section className="" id="add-blog-section">

--- a/frontend/src/components/forms/ProjectForm.tsx
+++ b/frontend/src/components/forms/ProjectForm.tsx
@@ -6,7 +6,6 @@ import { useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useNavigate } from "react-router";
 import { Button } from "../common/Button";
-import { ClipLoader } from "react-spinners";
 import TextFieldController from "../common/text-field/TextFieldController";
 import { HelperText } from "../common/HelperText";
 import ToggleButtonController from "../common/Toggle/toggle-button-controller";
@@ -19,6 +18,7 @@ import { usePublishProject } from "@/services/projects/publish-project";
 import CoverUploaderController from "../common/Uploader/CoverUploaderController";
 import { useDeleteProject } from "@/services/projects/delete-project";
 import TagInput from "../common/TagInput";
+import { EyeOff, Save, Send, Trash2 } from "lucide-react";
 
 interface IProjectFormComponentProps {
   defaultValues?: IProjectFormDefaultValues;
@@ -185,43 +185,56 @@ const ProjectForm: React.FC<IProjectFormComponentProps> = ({
 
   return (
     <>
-      <header className="flex items-center mb-3 gap-2 justify-end">
-        {defaultValues && (
+      <header className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <h1 className="text-xl font-bold">
+          {defaultValues ? "Edit project" : "Add a project"}
+        </h1>
+
+        <div className="flex items-center gap-2">
+          {defaultValues && (
+            <Button
+              size="sm"
+              colorType="error"
+              variant="outlined"
+              disabled={!defaultValues?.is_draft}
+              isLoading={deleteProjectMutation?.isDeleting}
+              icon={<Trash2 size={16} />}
+              onClick={deleteProjectHandler}
+            >
+              Delete
+            </Button>
+          )}
+
           <Button
-            colorType="error"
+            size="sm"
+            type="submit"
+            form="add-project"
             variant="outlined"
-            disabled={!defaultValues?.is_draft}
-            onClick={deleteProjectHandler}
+            colorType="success"
+            isLoading={isLoading}
+            icon={<Save size={16} />}
           >
-            {deleteProjectMutation?.isDeleting ? (
-              <ClipLoader size={10} />
-            ) : (
-              "Delete"
-            )}
+            Save
           </Button>
-        )}
 
-        <Button
-          size="sm"
-          type="submit"
-          form="add-project"
-          variant="outlined"
-          colorType="success"
-        >
-          {isLoading ? <ClipLoader size={10} /> : "Save"}
-        </Button>
-
-        {defaultValues && (
-          <Button size="sm" colorType="success" onClick={handlePublishBlog}>
-            {isPublishing ? (
-              <ClipLoader size={10} />
-            ) : defaultValues?.is_draft ? (
-              "Publish"
-            ) : (
-              "Unpublish"
-            )}
-          </Button>
-        )}
+          {defaultValues && (
+            <Button
+              size="sm"
+              colorType="success"
+              isLoading={isPublishing}
+              icon={
+                defaultValues?.is_draft ? (
+                  <Send size={16} />
+                ) : (
+                  <EyeOff size={16} />
+                )
+              }
+              onClick={handlePublishBlog}
+            >
+              {defaultValues?.is_draft ? "Publish" : "Unpublish"}
+            </Button>
+          )}
+        </div>
       </header>
 
       <section className="" id="add-project-section">


### PR DESCRIPTION
- Header nav: "Write Blog" / "Add Project" now render as filled green CTAs with a + icon; other links get pill-style hover/active states.
- Blog & project editors: titled header ("Write a blog" / "Edit project"), with Save / Publish / Delete as icon buttons (lucide) using the Button's built-in loading state.
- Cards: status badge is now semantic — green "published" vs amber "draft" (was red for both) — as rounded pills; cards surface up to 3 tag chips; ProjectCard drops the hardcoded "2 min read" in favor of real tags.

Verified: frontend `tsc -b && vite build` green.