### PR TITLE
docs(deploy): handoff-ready guide + configurable ports + stack.env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Deployment config with environment-specific values — keep the example only.
+stack.env

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,35 +1,58 @@
 # Deploying Notiq (Docker Swarm)
 
-Production deployment uses two images — `notiq-backend` (Express API + Postgres
-migrations) and `notiq-frontend` (the panel built to static files, served by
-nginx) — orchestrated by [`docker-stack.yml`](docker-stack.yml) with a Postgres
-service, named volumes, and Swarm secrets.
+Production deployment uses two images — `notiq-backend` (Express API; applies
+Postgres migrations on boot) and `notiq-frontend` (the panel built to static
+files, served by nginx) — orchestrated by [`docker-stack.yml`](docker-stack.yml)
+with a Postgres service, named volumes, and Swarm secrets.
 
 ```
-            ┌────────────┐         ┌────────────┐        ┌──────────┐
-  :80  ───▶ │  frontend  │   :8080 │  backend   │ ─────▶ │ postgres │
-  (nginx SPA)│  (×2)      │  ◀──────│  (×2)      │        │  (×1)    │
-            └────────────┘  API    └────────────┘        └──────────┘
-                                     uploads_data vol      db_data vol
+   FRONTEND_PORT(:80)        BACKEND_PORT(:8080)
+        │                          │
+        ▼                          ▼
+   ┌──────────┐   API calls   ┌──────────┐        ┌──────────┐
+   │ frontend │ ────────────▶ │ backend  │ ─────▶ │ postgres │
+   │ nginx ×2 │               │   ×2     │        │   ×1     │
+   └──────────┘               └──────────┘        └──────────┘
+                            uploads_data vol     db_data vol
 ```
 
-> **TLS:** the stack publishes plain HTTP (`:80`, `:8080`). In production put it
-> behind a TLS-terminating reverse proxy (Traefik, Caddy, nginx, or a cloud LB).
+This stack was smoke-tested end-to-end (deploy → migrations → signup → login →
+public API → SPA) before release.
+
+> **TLS:** the stack publishes plain HTTP. In production put it behind a
+> TLS-terminating reverse proxy (Caddy, Traefik, nginx, or a cloud LB) — see
+> [§7](#7-tls--reverse-proxy). Never expose the auth API over plain HTTP.
+
+---
+
+## 0. Handoff checklist
+
+If you're handing this to someone to deploy, they need:
+
+- [ ] This repo (for `docker-stack.yml`, `stack.env.example`, the Dockerfiles).
+- [ ] Either **pushed images** in a registry they can pull, **or** the repo to
+      build the images themselves.
+- [ ] Three secret values to create: a **JWT secret**, a **DB password**, and a
+      **DB URL** embedding that password.
+- [ ] The public **domains**: where the panel and the consuming site will live
+      (for `CORS_ORIGINS` and the frontend build arg).
+- [ ] A host with **Docker Engine + Swarm** and a **TLS reverse proxy**.
 
 ---
 
 ## 1. Prerequisites
 
-- Docker Engine with Swarm mode: `docker swarm init`
-- A container registry you can push to (Docker Hub, GHCR, a private registry).
-  For a single-node Swarm you can skip the registry and build locally.
+- Docker Engine with Swarm mode enabled: `docker swarm init`
+- A container registry to pull from (Docker Hub, GHCR, …). On a **single-node**
+  Swarm you can build locally and skip the registry (deploy with
+  `--resolve-image never`, see [Troubleshooting](#10-troubleshooting)).
 
 ---
 
 ## 2. Build & push the images
 
 The frontend bakes its API URL at **build time**, so set `VITE_API_BASE_URL` to
-the backend's public URL when you build it.
+the backend's public URL when building it.
 
 ```bash
 export REGISTRY=ghcr.io/yourname    # or your Docker Hub user
@@ -48,10 +71,25 @@ docker push $REGISTRY/notiq-frontend:$TAG
 
 ---
 
-## 3. Create the secrets
+## 3. Configure (stack.env)
+
+Copy the template and fill it in:
+
+```bash
+cp stack.env.example stack.env
+$EDITOR stack.env       # REGISTRY, TAG, CORS_ORIGINS, POSTGRES_USER/DB, ports
+```
+
+`CORS_ORIGINS` must list every browser origin that calls the API — the panel
+**and** the public site consuming the public API, comma-separated.
+
+---
+
+## 4. Create the secrets
 
 The stack reads three Swarm secrets. `db_url` is the full Prisma connection
-string and **must** embed the same password as `db_password`.
+string and **must** embed the same password as `db_password`, and the same
+`POSTGRES_USER`/`POSTGRES_DB` you set in `stack.env`.
 
 ```bash
 printf 'a-long-random-string'                              | docker secret create jwt_secret -
@@ -64,61 +102,101 @@ printf 'postgresql://blog_user:super-secret-db-password@db:5432/blog_panel' \
 
 ---
 
-## 4. Configure & deploy
+## 5. Deploy
 
-`docker stack deploy` substitutes variables from your shell environment:
+Load `stack.env` into the environment, then deploy:
 
 ```bash
-export REGISTRY=ghcr.io/yourname
-export TAG=1.0.0
-export CORS_ORIGINS=https://panel.example.com,https://www.example.com
-export POSTGRES_USER=blog_user
-export POSTGRES_DB=blog_panel
-
+set -a && . ./stack.env && set +a
 docker stack deploy -c docker-stack.yml notiq
 ```
 
-On boot the backend entrypoint loads the secrets, runs `prisma migrate deploy`,
-then starts the API. With multiple replicas, Prisma's migration advisory lock
-serializes them — only one applies the migrations. If the DB isn't ready yet the
-container exits and Swarm restarts it until it succeeds.
+On boot, each backend replica's entrypoint resolves the `*_FILE` secrets, runs
+`prisma migrate deploy`, then starts the API. Prisma's migration advisory lock
+serializes replicas, so only one applies migrations. **On first boot the backend
+may restart a couple of times while Postgres initializes** — the `on-failure`
+restart policy handles this; it settles within a minute.
 
 ---
 
-## 5. Verify
+## 6. Verify
 
 ```bash
-docker stack services notiq          # all replicas should reach n/n
-docker service logs notiq_backend -f # watch migrations + startup
-curl -fsS http://<host>:8080/health  # {"status":"ok",...}
+docker stack services notiq            # db 1/1, backend 2/2, frontend 2/2
+docker service logs notiq_backend -f   # watch migrations + startup
+
+HOST=127.0.0.1                         # or the server's address
+curl -fsS http://$HOST:8080/health     # {"status":"ok",...}
+
+# functional check (matches the release smoke test)
+curl -s -X POST http://$HOST:8080/sign-up -H 'Content-Type: application/json' \
+  -d '{"first_name":"Demo","last_name":"User","email":"demo@example.com","password":"Demo123!"}'
+curl -s -X POST http://$HOST:8080/login  -H 'Content-Type: application/json' \
+  -d '{"email":"demo@example.com","password":"Demo123!"}'      # → token + refreshToken
+curl -s "http://$HOST:8080/public/demo-user/blog"              # → {"data":[],"meta":{...}}
 ```
 
 ---
 
-## 6. Update (rolling, zero-downtime)
+## 7. TLS / reverse proxy
+
+Terminate TLS in front of the published ports and forward `X-Forwarded-*` (the
+backend builds absolute upload URLs from the request host/proto, and trusts the
+first proxy hop). Example with **Caddy** (automatic HTTPS):
+
+```caddy
+panel.example.com {
+    reverse_proxy 127.0.0.1:80      # FRONTEND_PORT
+}
+api.example.com {
+    reverse_proxy 127.0.0.1:8080    # BACKEND_PORT
+}
+```
+
+Then build the frontend with `VITE_API_BASE_URL=https://api.example.com` and set
+`CORS_ORIGINS=https://panel.example.com,https://www.example.com`.
+
+---
+
+## 8. Update (rolling, zero-downtime)
 
 Build & push a new `TAG`, then redeploy — `update_config: order: start-first`
 brings up the new task before stopping the old one:
 
 ```bash
-export TAG=1.0.1
-# rebuild + push both images...
+# bump TAG in stack.env, rebuild + push both images, then:
+set -a && . ./stack.env && set +a
 docker stack deploy -c docker-stack.yml notiq
 ```
 
 ---
 
-## 7. Backups
+## 9. Backups
 
 ```bash
 # Database
 docker exec $(docker ps -qf name=notiq_db) \
-  pg_dump -U blog_user blog_panel > backup-$(date +%F).sql
+  pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB" > backup-$(date +%F).sql
 
 # Uploaded media (named volume)
 docker run --rm -v notiq_uploads_data:/data -v "$PWD":/backup busybox \
   tar czf /backup/uploads-$(date +%F).tar.gz -C /data .
 ```
+
+Schedule both on a cron and ship them off-host.
+
+---
+
+## 10. Troubleshooting
+
+| Symptom | Cause / fix |
+| --- | --- |
+| `image ... not found` on deploy | Locally-built images aren't in a registry. On a single-node Swarm deploy with `docker stack deploy --resolve-image never -c docker-stack.yml notiq`, or push to a registry. |
+| Backend tasks show `Failed` then `Running` early on | Expected: it raced Postgres on first boot and self-healed. Confirm it reaches `2/2`. |
+| `curl http://localhost:8080/...` hangs locally | `localhost` may resolve to IPv6 `::1` while the published port binds IPv4 — use `127.0.0.1` or the host IP. |
+| Browser blocked by CORS | Add the exact origin (scheme + host) to `CORS_ORIGINS` and redeploy. |
+| Uploaded image URLs use the wrong host | Make the reverse proxy forward `Host` and `X-Forwarded-Proto`. |
+| DB auth fails | `db_url`'s embedded password/user/db must match the `db_password` secret and `POSTGRES_USER`/`POSTGRES_DB`. |
 
 ---
 

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -5,7 +5,8 @@
 # Prerequisites (see DEPLOY.md):
 #   - Built + pushed images (REGISTRY/notiq-backend, REGISTRY/notiq-frontend)
 #   - Swarm secrets: jwt_secret, db_password, db_url
-#   - Optional env overrides: REGISTRY, TAG, CORS_ORIGINS, POSTGRES_USER, POSTGRES_DB
+#   - Config via env (or stack.env): REGISTRY, TAG, CORS_ORIGINS, POSTGRES_USER,
+#     POSTGRES_DB, BACKEND_PORT, FRONTEND_PORT
 
 services:
   db:
@@ -51,7 +52,8 @@ services:
     networks:
       - blog_net
     ports:
-      - "8080:8080"
+      # host:container — host port configurable so it can sit behind a proxy
+      - "${BACKEND_PORT:-8080}:8080"
     init: true
     # Healthcheck + graceful shutdown come from the image (Dockerfile + app.ts).
     deploy:
@@ -72,7 +74,7 @@ services:
     networks:
       - blog_net
     ports:
-      - "80:80"
+      - "${FRONTEND_PORT:-80}:80"
     deploy:
       replicas: 2
       restart_policy:

--- a/stack.env.example
+++ b/stack.env.example
@@ -1,0 +1,21 @@
+# Configuration for `docker stack deploy` (see DEPLOY.md).
+# Copy to stack.env, fill in, then load it before deploying:
+#   set -a && . ./stack.env && set +a
+#   docker stack deploy -c docker-stack.yml notiq
+
+# Registry + tag of the images you built and pushed.
+REGISTRY=ghcr.io/yourname
+TAG=1.0.0
+
+# Browser origins allowed to call the API (your panel UI + the public site
+# that consumes the public API), comma-separated.
+CORS_ORIGINS=https://panel.example.com,https://www.example.com
+
+# Postgres database name + user (the password comes from the db_password secret).
+POSTGRES_USER=blog_user
+POSTGRES_DB=blog_panel
+
+# Host ports to publish. Leave at the defaults if you terminate TLS with a
+# reverse proxy in front; change them to avoid collisions on the host.
+BACKEND_PORT=8080
+FRONTEND_PORT=80


### PR DESCRIPTION
Validated the full Swarm stack end-to-end locally (deploy → migrations → signup → login → public API → SPA, all green) and hardened the delivery:

- docker-stack.yml: published ports are now configurable via BACKEND_PORT / FRONTEND_PORT (default 8080 / 80) so the stack can sit behind a proxy.
- stack.env.example: single place to configure REGISTRY, TAG, CORS_ORIGINS, POSTGRES_USER/DB, and ports; loaded with `set -a && . ./stack.env`.
- .gitignore: ignore the filled-in stack.env (keep the example).
- DEPLOY.md rewritten for third-party handoff: handoff checklist, build/push, stack.env config, secret creation, deploy, functional verify curls, a TLS reverse-proxy (Caddy) section, rolling updates, backups, and a troubleshooting table (first-boot DB race, --resolve-image never for local images, localhost→IPv6 gotcha, CORS, forwarded headers).